### PR TITLE
Add script to generate figures and tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ Rscript scripts/figure_setup/sync-metadata.R
 Rscript scripts/figure_setup/sync-data-files.R
 ```
 
+If you have setup `1Password` to handle your AWS credentials, you will need to prefix those lines with `op run --`:
+
+```sh
+op run -- Rscript scripts/figure_setup/sync-metadata.R
+op run -- Rscript scripts/figure_setup/sync-data-files.R
+```
+
+
 ## Sample info
 
 The `sample_info` folder contains metadata files used to create figures and tables.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repo contains the figures and tables included in the ScPCA manuscript.
 
 ## Summary of figures and tables
 
-Below is a summary of all figures in the paper.
+Below is a summary of all figures and tables in the paper.
 
 **Figure 1**
 
@@ -35,7 +35,22 @@ B. Simplified versions of plots in the main QC report.
 
 The `figures` and `tables` folders contain the most up-to-date version of each of the figures and tables, respectively.
 The `scripts` directory contains all scripts used to create the figures and tables.
-See the [`README` for the `scripts` directory](./scripts/README.md) for more information on generating figures.
+See the [`README` for the `scripts` directory](./scripts/README.md) for more information on figure and table scripts.
+
+To generate all figures and tables, run the script [`generate-figures-tables.sh`](generate-figures-tables.sh) as:
+
+```sh
+bash generate-figures-tables.sh
+```
+
+Note that this script assumes that the `s3_files` directory has been populated with relevant data files.
+These files can be obtained by first running the figure setup scripts, which currently require S3 bucket access as a Data Lab member.
+Setup scripts can be run as:
+
+```sh
+Rscript scripts/figure_setup/sync-metadata.R
+Rscript scripts/figure_setup/sync-data-files.R
+```
 
 ## Sample info
 

--- a/generate-figures-tables.sh
+++ b/generate-figures-tables.sh
@@ -13,8 +13,7 @@
 # bash generate-figures-tables.sh
 
 # enviroment settings
-set -e
-set -o pipefail
+set -euo pipefail
 
 # Find and go to base directory, which is where this script lives
 BASEDIR=$(dirname "${BASH_SOURCE[0]}")

--- a/generate-figures-tables.sh
+++ b/generate-figures-tables.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# This bash script runs all scripts to generate manuscript figures and tables.
+# This script assumes that you already have locally downloaded the necessary data from S3.
+# Currently, this requires that you have access to the relevant S3 bucket as a Data Lab member.
+#
+# To obtain all data, first run the following scripts (paths are relative to the base directory)
+#
+# Rscript scripts/figure_setup/sync-data-files.R
+# Rscript scripts/figure_setup/sync-metadata.R
+#
+# This script can be run as:
+# bash generate-figures-tables.sh
+
+# enviroment settings
+set -e
+set -o pipefail
+
+# Find and go to base directory, which is where this script lives
+BASEDIR=$(dirname "${BASH_SOURCE[0]}")
+cd "$BASEDIR"
+
+# Define path to figure/table generation scripts
+script_dir=${BASEDIR}/scripts
+
+# Ensure output directories exist
+mkdir -p ${BASEDIR}/figures/pngs
+mkdir -p ${BASEDIR}/tables
+
+#########################################################
+#        Generate figures in order of appearance        #
+#########################################################
+
+
+### Main text figures ###
+
+# Figure 1A
+Rscript ${script_dir}/Fig1A_sample-disease-barchart.R
+
+# Figure 1B
+Rscript ${script_dir}/Fig1B_modality-barchart.R
+
+# Figure 2B
+Rscript ${script_dir}/Fig2B_qc-plots.R
+
+
+### Supplementary text figures ###
+
+# Figure S1A
+Rscript ${script_dir}/FigS1A_memory-time-comparison.R
+
+
+##########################################################
+#         Generate tables in order of appearance         #
+##########################################################
+
+
+### Supplementary text tables ###
+
+Rscript ${script_dir}/TableS1_modality-summary.R
+
+
+
+
+
+
+##########################################################
+#                        Clean up                        #
+##########################################################
+
+rm -f Rplots.pdf

--- a/renv.lock
+++ b/renv.lock
@@ -3,6 +3,26 @@
     "Version": "4.3.1",
     "Repositories": [
       {
+        "Name": "BioCsoft",
+        "URL": "https://bioconductor.org/packages/3.18/bioc"
+      },
+      {
+        "Name": "BioCann",
+        "URL": "https://bioconductor.org/packages/3.18/data/annotation"
+      },
+      {
+        "Name": "BioCexp",
+        "URL": "https://bioconductor.org/packages/3.18/data/experiment"
+      },
+      {
+        "Name": "BioCworkflows",
+        "URL": "https://bioconductor.org/packages/3.18/workflows"
+      },
+      {
+        "Name": "BioCbooks",
+        "URL": "https://bioconductor.org/packages/3.18/books"
+      },
+      {
         "Name": "CRAN",
         "URL": "https://packagemanager.posit.co/cran/latest"
       }
@@ -112,6 +132,7 @@
       "Package": "BiocVersion",
       "Version": "3.18.1",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.18",
       "Requirements": [
         "R"
       ],
@@ -429,6 +450,7 @@
       "Package": "S4Vectors",
       "Version": "0.40.2",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.18",
       "Requirements": [
         "BiocGenerics",
         "R",
@@ -887,6 +909,35 @@
       ],
       "Hash": "899f28fe0388b7f687d7453429c2474d"
     },
+    "ggforce": {
+      "Package": "ggforce",
+      "Version": "0.4.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "MASS",
+        "R",
+        "Rcpp",
+        "RcppEigen",
+        "cli",
+        "ggplot2",
+        "grDevices",
+        "grid",
+        "gtable",
+        "lifecycle",
+        "polyclip",
+        "rlang",
+        "scales",
+        "stats",
+        "systemfonts",
+        "tidyselect",
+        "tweenr",
+        "utils",
+        "vctrs",
+        "withr"
+      ],
+      "Hash": "a06503f54e227f79b45a72df2946a2d2"
+    },
     "ggpattern": {
       "Package": "ggpattern",
       "Version": "1.0.1",
@@ -1297,6 +1348,16 @@
       ],
       "Hash": "bd54ba8a0a5faded999a7aab6e46b374"
     },
+    "polyclip": {
+      "Package": "polyclip",
+      "Version": "1.10-6",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "436542aadb70675e361cf359285af7c7"
+    },
     "prettyunits": {
       "Package": "prettyunits",
       "Version": "1.2.0",
@@ -1680,6 +1741,21 @@
         "withr"
       ],
       "Hash": "79540e5fcd9e0435af547d885f184fd5"
+    },
+    "tweenr": {
+      "Package": "tweenr",
+      "Version": "2.0.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "cpp11",
+        "farver",
+        "magrittr",
+        "rlang",
+        "vctrs"
+      ],
+      "Hash": "c16efcef4c72d3bff5e65031f3f1f841"
     },
     "tzdb": {
       "Package": "tzdb",


### PR DESCRIPTION
Closes #23 

This PR adds a bash script to generate figures and tables, as well as associated documentation. The script was somewhat inspired by organizational choices in our dear old friend, the [OpenPBTA figure generation script](https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/figures/generate-figures.sh).

The script is called `generate-figures-tables.sh` and lives in the top-level directory. I ran the script to ensure it worked, and indeed it did! But on the way I had some `renv` problems, and it seemed that `ggforce` hadn't yet been snapshotted into the lockfile, so that is done here as well. The snapshot added some BioC refs which seems fine. 
I also included a bonus line to purge `Rplots.pdf`, which gets created all the time and nobody really knows why (well, I certainly have never known why and gave up trying to figure it out a long time ago - it's something to do with ggplot innards...) 

Now, when we write new scripts, we'll want to make sure to add them into this bash script as we go.

Note also my wording that "currently, only data lab members can do the S3 things." I assume when the paper goes out we'll make that bucket public, and we can change up some of that wording. But, since this repo is already public, I figured it's the right language for now. We probably don't _need_ it though, so let me know what you think.