### PR TITLE
Add table with list of references used from Panglao and associated organs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Summary of libraries and types of libraries found on the Portal.
 
 **Table S2**
 
-List of references used for each project on Portal with `CellAssign`, including the list of organs used to create the reference.
+List of references used for each project on the Portal with `CellAssign`, including the list of organs used to create the reference.
 
 
 ## Generating figures and tables

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Comparison between submitter provided annotations and automated annotations from
 
 Summary of libraries and types of libraries found on the Portal.
 
+**Table S2**
+
+List of references used for each project on Portal with `CellAssign`, including the list of organs used to create the reference.
+
 
 ## Generating figures and tables
 

--- a/generate-figures-tables.sh
+++ b/generate-figures-tables.sh
@@ -85,7 +85,7 @@ Rscript ${script_dir}/FigS5_submitter-celltypes-heatmap.R
 
 Rscript ${script_dir}/TableS1_modality-summary.R
 
-
+Rscript ${script_dir}/TableS2_cellassign-ref-summary.R
 
 
 

--- a/sample-info/celltype-reference-metadata.tsv
+++ b/sample-info/celltype-reference-metadata.tsv
@@ -1,0 +1,20 @@
+celltype_ref_name	celltype_ref_source	celltype_method	organs
+adrenal-compartment	PanglaoDB	CellAssign	Adrenal glands, Connective tissue, Immune system, Embryo, Vasculature
+adrenal-pancreas-reproductive	PanglaoDB	CellAssign	Adrenal glands,  Connective tissue, Embryo, Immune system, Pancreas, Reproductive, Smooth muscle, Vasculature
+all-cancers	PanglaoDB	CellAssign	Adrenal glands, Blood, Bone, Brain, Connective tissue, Embryo, Epithelium, Eye, GI tract, Immune system, Kidney, Liver, Lungs, Mammary gland, Olfactory system, Oral cavity, Pancreas, Parathyroid glands, Reproductive, Skeletal muscle, Skin, Smooth muscle, Thymus, Thyroid, Urinary bladder, Vasculature, Zygote
+blood-compartment	PanglaoDB	CellAssign	Blood, Bone, Immune system
+bone-and-soft-tissue	PanglaoDB	CellAssign	Bone, Connective tissue, Embryo, Immune system, Smooth muscle, Vasculature
+bone-compartment	PanglaoDB	CellAssign	Bone, Connective tissue, Immune system, Vasculature
+brain-compartment	PanglaoDB	CellAssign	Brain, Embryo, Immune system, Vasculature
+eye-compartment	PanglaoDB	CellAssign	Embryo, Eye, Immune system, Vasculature
+kidney-compartment	PanglaoDB	CellAssign	Embryo, Immune system, Kidney, Vasculature
+liver-compartment	PanglaoDB	CellAssign	Connective tissue, Embryo, Immune system, Liver, Vasculature
+lung-compartment	PanglaoDB	CellAssign	Connective tissue, Embryo, Immune system, Lungs, Vasculature
+muscle-compartment	PanglaoDB	CellAssign	Connective tissue, Embryo, Immune system, Skeletal muscle, Smooth muscle, Vasculature
+pancreas-compartment	PanglaoDB	CellAssign	Connective tissue, Embryo, Immune system, Pancreas, Vasculature
+pediatric-cancers	PanglaoDB	CellAssign	Adrenal glands, Blood, Bone, Brain, Connective tissue, Embryo, Epithelium, Eye, GI tract, Immune system, Kidney, Liver, Lungs, Oral cavity, Pancreas, Parathyroid glands, Reproductive, Skeletal muscle, Skin, Smooth muscle, Thymus, Thyroid, Urinary bladder, Vasculature, Zygote
+reproductive-compartment	PanglaoDB	CellAssign	Embryo, Immune system, Reproductive, Vasculature
+BlueprintEncodeData	celldex	SingleR	NA
+DatabaseImmuneCellExpressionData	celldex	SingleR	NA
+HumanPrimaryCellAtlasData	celldex	SingleR	NA
+MonacoImmuneData	celldex	SingleR	NA

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -71,3 +71,6 @@ Before running this script, you must run `figure_setup/sync-data-files.R`.
 
 11. `FigS5_submitter-celltypes-heatmap.R`: This script is used to generate supplemental Figure 5, which includes an example heatmap comparing submitter provided annotations to automated annotations from `SingleR` and `CellAssign`.
 Before running this script, you must run `figure_setup/sync-data-files.R`.
+
+12. `TableS2_cellassign-ref-summary.R`: This script is used to generate supplemental Table 2, which includes one row for each ScPCA project on the Portal and the associated diagnoses, reference used from `PanglaoDB`, and list of organs used to construct the reference.
+Before running this script, you must run `figure_setup/sync-metadata.R`

--- a/scripts/TableS2_cellassign-ref-summary.R
+++ b/scripts/TableS2_cellassign-ref-summary.R
@@ -44,15 +44,15 @@ grouped_sample_df <- sample_df |>
   dplyr::filter(scpca_project_id %in% project_df$scpca_project_id) |> 
   dplyr::group_by(scpca_project_id) |> 
   # create a list of diagnoses for each project
-  dplyr::summarize(Diagnoses = paste(unique(diagnosis), collapse = ", ")) |> 
+  dplyr::summarize(Diagnoses = paste(sort(unique(diagnosis)), collapse = ", ")) |> 
   # add ref name
   dplyr::left_join(project_df) |> 
   # add organs
   dplyr::left_join(panglao_df, by = c("cellassign_ref_name" = "celltype_ref_name")) |> 
   dplyr::rename(
     "ScPCA Project ID" = "scpca_project_id",
-    "PanglaoDB reference name" = "cellassign_ref_name",
-    "Organs included in reference" = "organs"
+    "ScPCA reference name" = "cellassign_ref_name",
+    "PanglaoDB organs included in reference" = "organs"
   )
 
 # export table 

--- a/scripts/TableS2_cellassign-ref-summary.R
+++ b/scripts/TableS2_cellassign-ref-summary.R
@@ -1,0 +1,60 @@
+# This script creates a table showing the compilation of all references 
+# built for CellAssign from PanglaoDB
+# specifically one row per project, with list of diagnoses, ref name, and organ list
+
+renv::load()
+
+# Set up -----------------------------------------------------------------------
+
+# sample metadata file
+# need to summarize diagnoses for each project
+sample_metadata_file <- here::here("s3_files", "scpca-sample-metadata.tsv")
+
+# panglao reference metadata
+# need this to get list of organs and ref name
+panglao_metadata_file <- here::here("sample-info", "celltype-reference-metadata.tsv")
+
+# project celltype metadata 
+# need this to get ref name for each project
+project_metadata_file <- here::here("s3_files", "scpca-project-celltype-metadata.tsv")
+
+# output table 
+table_dir <- here::here("tables")
+fs::dir_create(table_dir)
+output_table_file <- file.path(table_dir, "TableS2_cellassign-ref-summary.tsv")
+
+# Prepare table ----------------------------------------------------------------
+
+# read in all metadata 
+sample_df <- readr::read_tsv(sample_metadata_file)
+project_df <- readr::read_tsv(project_metadata_file)
+# only keep ref name and organs for joining later 
+panglao_df <- readr::read_tsv(panglao_metadata_file) |> 
+  dplyr::select(celltype_ref_name, organs)
+
+# filter project df to include only projects with a cellassign ref
+project_df <- project_df |> 
+  dplyr::filter(!is.na(cellassign_ref_name)) |> 
+  # only keep project ID and ref name for joining 
+  dplyr::select(scpca_project_id, cellassign_ref_name)
+
+grouped_sample_df <- sample_df |> 
+  dplyr::select(scpca_project_id, diagnosis) |> 
+  # remove any projects that don't have cell assign refs
+  dplyr::filter(scpca_project_id %in% project_df$scpca_project_id) |> 
+  dplyr::group_by(scpca_project_id) |> 
+  # create a list of diagnoses for each project
+  dplyr::summarize(Diagnoses = paste(unique(diagnosis), collapse = ", ")) |> 
+  # add ref name
+  dplyr::left_join(project_df) |> 
+  # add organs
+  dplyr::left_join(panglao_df, by = c("cellassign_ref_name" = "celltype_ref_name")) |> 
+  dplyr::rename(
+    "ScPCA Project ID" = "scpca_project_id",
+    "PanglaoDB reference name" = "cellassign_ref_name",
+    "Organs included in reference" = "organs"
+  )
+
+# export table 
+readr::write_tsv(grouped_sample_df, output_table_file)
+

--- a/scripts/figure_setup/sync-metadata.R
+++ b/scripts/figure_setup/sync-metadata.R
@@ -4,6 +4,7 @@
 # path to metadata stored on S3
 sample_metadata_s3 <- 's3://ccdl-scpca-data/sample_info/scpca-sample-metadata.tsv'
 library_metadata_s3 <- 's3://ccdl-scpca-data/sample_info/scpca-library-metadata.tsv'
+celltype_metadata_s3 <- 's3://ccdl-scpca-data/sample_info/scpca-project-celltype-metadata.tsv'
 
 # create a directory to store S3 files 
 local_s3_dir <- here::here("s3_files")
@@ -17,4 +18,9 @@ system(sync_call)
 # copy library metadata
 local_library_metadata <- file.path(local_s3_dir, "scpca-library-metadata.tsv")
 sync_call <- paste('aws s3 cp', library_metadata_s3, local_s3_dir, sep = " ")
+system(sync_call)
+
+# copy celltype ref metadata 
+local_celltype_metadata <- file.path(local_s3_dir, "scpca-project-celltype-metadata.tsv")
+sync_call <- glue::glue("aws s3 cp '{celltype_metadata_s3}' '{local_celltype_metadata}'")
 system(sync_call)

--- a/tables/TableS2_cellassign-ref-summary.tsv
+++ b/tables/TableS2_cellassign-ref-summary.tsv
@@ -1,18 +1,18 @@
-ScPCA Project ID	Diagnoses	PanglaoDB reference name	Organs included in reference
-SCPCP000001	Anaplastic glioma, Glioblastoma, High-grade glioma, Diffuse midline glioma, Non-cancerous, Pleomorphic xanthoastrocytoma, Anaplastic astrocytoma	brain-compartment	Brain, Embryo, Immune system, Vasculature
-SCPCP000002	Pilocytic astrocytoma, Ganglioglioma, Low-grade glioma, Ganglioglioma/ATRT, Ependymoma	brain-compartment	Brain, Embryo, Immune system, Vasculature
-SCPCP000003	T-myeloid mixed phenotype acute leukemia, Early T-cell precursor T-cell acute lymphoblastic leukemia, Non-early T-cell precursor T-cell acute lymphoblastic leukemia, Acute myeloid leukemia	blood-compartment	Blood, Bone, Immune system
+ScPCA Project ID	Diagnoses	ScPCA reference name	PanglaoDB organs included in reference
+SCPCP000001	Anaplastic astrocytoma, Anaplastic glioma, Diffuse midline glioma, Glioblastoma, High-grade glioma, Non-cancerous, Pleomorphic xanthoastrocytoma	brain-compartment	Brain, Embryo, Immune system, Vasculature
+SCPCP000002	Ependymoma, Ganglioglioma, Ganglioglioma/ATRT, Low-grade glioma, Pilocytic astrocytoma	brain-compartment	Brain, Embryo, Immune system, Vasculature
+SCPCP000003	Acute myeloid leukemia, Early T-cell precursor T-cell acute lymphoblastic leukemia, Non-early T-cell precursor T-cell acute lymphoblastic leukemia, T-myeloid mixed phenotype acute leukemia	blood-compartment	Blood, Bone, Immune system
 SCPCP000004	Neuroblastoma	adrenal-compartment	Adrenal glands, Connective tissue, Immune system, Embryo, Vasculature
 SCPCP000005	Rhabdomyosarcoma	muscle-compartment	Connective tissue, Embryo, Immune system, Skeletal muscle, Smooth muscle, Vasculature
 SCPCP000006	Wilms tumor	kidney-compartment	Embryo, Immune system, Kidney, Vasculature
-SCPCP000007	Acute myeloid leukemia, T-myeloid mixed phenotype acute leukemia, Non-cancerous	blood-compartment	Blood, Bone, Immune system
-SCPCP000008	Early T-cell precursor T-cell acute lymphoblastic leukemia, B-cell acute lymphoblastic leukemia, Mixed phenotype acute leukemia, T-cell acute lymphoblastic leukemia	blood-compartment	Blood, Bone, Immune system
-SCPCP000009	Medulloblastoma, Ependymoma, Pilocytic astrocytoma, Dysplastic gangliocytoma, Primitive neuroectodermal tumor, Desmoplastic ganglioglioma, Anaplastic ganglioglioma, Dysembryoplastic neuroepithelial tumor, Subependymoma, Low-grade glioma, Myxopapillary ependymoma, Non-cancerous, Glioblastoma, Anaplastic ependymoma, Pilomyxoid astrocytoma, Schwannoma, Ganglioglioma	brain-compartment	Brain, Embryo, Immune system, Vasculature
-SCPCP000010	Ganglioglioma, Low-grade glioma, Atypical teratoid rhabdoid tumor, Glial-neuronal tumor, Focal cortical dysplasia, High-grade glioma	brain-compartment	Brain, Embryo, Immune system, Vasculature
+SCPCP000007	Acute myeloid leukemia, Non-cancerous, T-myeloid mixed phenotype acute leukemia	blood-compartment	Blood, Bone, Immune system
+SCPCP000008	B-cell acute lymphoblastic leukemia, Early T-cell precursor T-cell acute lymphoblastic leukemia, Mixed phenotype acute leukemia, T-cell acute lymphoblastic leukemia	blood-compartment	Blood, Bone, Immune system
+SCPCP000009	Anaplastic ependymoma, Anaplastic ganglioglioma, Desmoplastic ganglioglioma, Dysembryoplastic neuroepithelial tumor, Dysplastic gangliocytoma, Ependymoma, Ganglioglioma, Glioblastoma, Low-grade glioma, Medulloblastoma, Myxopapillary ependymoma, Non-cancerous, Pilocytic astrocytoma, Pilomyxoid astrocytoma, Primitive neuroectodermal tumor, Schwannoma, Subependymoma	brain-compartment	Brain, Embryo, Immune system, Vasculature
+SCPCP000010	Atypical teratoid rhabdoid tumor, Focal cortical dysplasia, Ganglioglioma, Glial-neuronal tumor, High-grade glioma, Low-grade glioma	brain-compartment	Brain, Embryo, Immune system, Vasculature
 SCPCP000011	Retinoblastoma	eye-compartment	Embryo, Eye, Immune system, Vasculature
 SCPCP000012	Adrenocortical carcinoma, Germ cell tumor, Hepatoblastoma, Melanoma	adrenal-pancreas-reproductive	Adrenal glands,  Connective tissue, Embryo, Immune system, Pancreas, Reproductive, Smooth muscle, Vasculature
-SCPCP000013	Clear cell sarcoma of the kidney, Clear cell sarcoma, Desmoplastic small round cell tumor, Gastrointestinal stromal tumor, Spindle sarcoma, Infantile fibrosarcoma, Synovial sarcoma, Undifferentiated round cell sarcoma, Epithelioid sarcoma, Embryonal sarcoma, High-grade sarcoma	bone-and-soft-tissue	Bone, Connective tissue, Embryo, Immune system, Smooth muscle, Vasculature
+SCPCP000013	Clear cell sarcoma, Clear cell sarcoma of the kidney, Desmoplastic small round cell tumor, Embryonal sarcoma, Epithelioid sarcoma, Gastrointestinal stromal tumor, High-grade sarcoma, Infantile fibrosarcoma, Spindle sarcoma, Synovial sarcoma, Undifferentiated round cell sarcoma	bone-and-soft-tissue	Bone, Connective tissue, Embryo, Immune system, Smooth muscle, Vasculature
 SCPCP000014	Wilms tumor	kidney-compartment	Embryo, Immune system, Kidney, Vasculature
 SCPCP000015	Ewing sarcoma	bone-and-soft-tissue	Bone, Connective tissue, Embryo, Immune system, Smooth muscle, Vasculature
 SCPCP000016	Rhabdoid tumor	pediatric-cancers	Adrenal glands, Blood, Bone, Brain, Connective tissue, Embryo, Epithelium, Eye, GI tract, Immune system, Kidney, Liver, Lungs, Oral cavity, Pancreas, Parathyroid glands, Reproductive, Skeletal muscle, Skin, Smooth muscle, Thymus, Thyroid, Urinary bladder, Vasculature, Zygote
-SCPCP000021	High-grade glioma, Glioblastoma, Diffuse midline glioma, Infant-type hemispheric glioma	brain-compartment	Brain, Embryo, Immune system, Vasculature
+SCPCP000021	Diffuse midline glioma, Glioblastoma, High-grade glioma, Infant-type hemispheric glioma	brain-compartment	Brain, Embryo, Immune system, Vasculature

--- a/tables/TableS2_cellassign-ref-summary.tsv
+++ b/tables/TableS2_cellassign-ref-summary.tsv
@@ -1,0 +1,18 @@
+ScPCA Project ID	Diagnoses	PanglaoDB reference name	Organs included in reference
+SCPCP000001	Anaplastic glioma, Glioblastoma, High-grade glioma, Diffuse midline glioma, Non-cancerous, Pleomorphic xanthoastrocytoma, Anaplastic astrocytoma	brain-compartment	Brain, Embryo, Immune system, Vasculature
+SCPCP000002	Pilocytic astrocytoma, Ganglioglioma, Low-grade glioma, Ganglioglioma/ATRT, Ependymoma	brain-compartment	Brain, Embryo, Immune system, Vasculature
+SCPCP000003	T-myeloid mixed phenotype acute leukemia, Early T-cell precursor T-cell acute lymphoblastic leukemia, Non-early T-cell precursor T-cell acute lymphoblastic leukemia, Acute myeloid leukemia	blood-compartment	Blood, Bone, Immune system
+SCPCP000004	Neuroblastoma	adrenal-compartment	Adrenal glands, Connective tissue, Immune system, Embryo, Vasculature
+SCPCP000005	Rhabdomyosarcoma	muscle-compartment	Connective tissue, Embryo, Immune system, Skeletal muscle, Smooth muscle, Vasculature
+SCPCP000006	Wilms tumor	kidney-compartment	Embryo, Immune system, Kidney, Vasculature
+SCPCP000007	Acute myeloid leukemia, T-myeloid mixed phenotype acute leukemia, Non-cancerous	blood-compartment	Blood, Bone, Immune system
+SCPCP000008	Early T-cell precursor T-cell acute lymphoblastic leukemia, B-cell acute lymphoblastic leukemia, Mixed phenotype acute leukemia, T-cell acute lymphoblastic leukemia	blood-compartment	Blood, Bone, Immune system
+SCPCP000009	Medulloblastoma, Ependymoma, Pilocytic astrocytoma, Dysplastic gangliocytoma, Primitive neuroectodermal tumor, Desmoplastic ganglioglioma, Anaplastic ganglioglioma, Dysembryoplastic neuroepithelial tumor, Subependymoma, Low-grade glioma, Myxopapillary ependymoma, Non-cancerous, Glioblastoma, Anaplastic ependymoma, Pilomyxoid astrocytoma, Schwannoma, Ganglioglioma	brain-compartment	Brain, Embryo, Immune system, Vasculature
+SCPCP000010	Ganglioglioma, Low-grade glioma, Atypical teratoid rhabdoid tumor, Glial-neuronal tumor, Focal cortical dysplasia, High-grade glioma	brain-compartment	Brain, Embryo, Immune system, Vasculature
+SCPCP000011	Retinoblastoma	eye-compartment	Embryo, Eye, Immune system, Vasculature
+SCPCP000012	Adrenocortical carcinoma, Germ cell tumor, Hepatoblastoma, Melanoma	adrenal-pancreas-reproductive	Adrenal glands,  Connective tissue, Embryo, Immune system, Pancreas, Reproductive, Smooth muscle, Vasculature
+SCPCP000013	Clear cell sarcoma of the kidney, Clear cell sarcoma, Desmoplastic small round cell tumor, Gastrointestinal stromal tumor, Spindle sarcoma, Infantile fibrosarcoma, Synovial sarcoma, Undifferentiated round cell sarcoma, Epithelioid sarcoma, Embryonal sarcoma, High-grade sarcoma	bone-and-soft-tissue	Bone, Connective tissue, Embryo, Immune system, Smooth muscle, Vasculature
+SCPCP000014	Wilms tumor	kidney-compartment	Embryo, Immune system, Kidney, Vasculature
+SCPCP000015	Ewing sarcoma	bone-and-soft-tissue	Bone, Connective tissue, Embryo, Immune system, Smooth muscle, Vasculature
+SCPCP000016	Rhabdoid tumor	pediatric-cancers	Adrenal glands, Blood, Bone, Brain, Connective tissue, Embryo, Epithelium, Eye, GI tract, Immune system, Kidney, Liver, Lungs, Oral cavity, Pancreas, Parathyroid glands, Reproductive, Skeletal muscle, Skin, Smooth muscle, Thymus, Thyroid, Urinary bladder, Vasculature, Zygote
+SCPCP000021	High-grade glioma, Glioblastoma, Diffuse midline glioma, Infant-type hemispheric glioma	brain-compartment	Brain, Embryo, Immune system, Vasculature


### PR DESCRIPTION
Closes #75 

Here I'm adding a supplemental table that includes the list of references created from Panglao for use with CellAssign. For each ScPCA project, I included the reference name and then the list of organs from Panglao used to create the reference. I also included a list of diagnoses for each project to hopefully allow readers to see why some of the organs are included for each project. 

To create the table, I needed to get the ref name for each project from `scpca-celltype-project-metadata.tsv`, so I added that to the `sync-metadata.R` script. I also needed the list of organs, which is stored in the `references` directory in `scpca-nf` that doesn't sync anywhere. I just added that to the repo here in the `sample-info` directory. 