### PR TITLE
Add script to calculate TPM

### DIFF
--- a/analysis/bulk-deconvolution/README.md
+++ b/analysis/bulk-deconvolution/README.md
@@ -1,2 +1,12 @@
 This directory contains scripts and results for performing deconvolution on solid tumor bulk RNA-seq samples in ScPCA.
 
+To run the analysis, run:
+
+```sh
+bash run-deconolution.sh
+```
+
+If you use 1Password to manage your credentials, you may need to run:
+```sh
+op run -- bash run-deconolution.sh
+```

--- a/analysis/bulk-deconvolution/README.md
+++ b/analysis/bulk-deconvolution/README.md
@@ -3,10 +3,10 @@ This directory contains scripts and results for performing deconvolution on soli
 To run the analysis, run:
 
 ```sh
-bash run-deconolution.sh
+bash run-deconvolution.sh
 ```
 
 If you use 1Password to manage your credentials, you may need to run:
 ```sh
-op run -- bash run-deconolution.sh
+op run -- bash run-deconvolution.sh
 ```

--- a/analysis/bulk-deconvolution/run-deconvolution.sh
+++ b/analysis/bulk-deconvolution/run-deconvolution.sh
@@ -31,4 +31,3 @@ for project_dir in $salmon_quant_dir/*; do
     # forthcoming!
 
 done
-

--- a/analysis/bulk-deconvolution/run-deconvolution.sh
+++ b/analysis/bulk-deconvolution/run-deconvolution.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# This script runs this analysis and I will add more comments later.
-# If you are using 1P, you may need op run -- .
+# This script runs the bulk deconvolution analysis.
 
 set -euo pipefail
 

--- a/analysis/bulk-deconvolution/run-deconvolution.sh
+++ b/analysis/bulk-deconvolution/run-deconvolution.sh
@@ -12,11 +12,12 @@ cd "$basedir"
 data_dir="data"
 script_dir="scripts"
 salmon_quant_dir="${data_dir}/salmon-quant-files"
+reference_dir=${data_dir}/reference # stores the id map file
 tpm_dir="${data_dir}/tpm"
 
-# Step 0: Download quant.sf files if they do not exist
-if [ ! -d $salmon_quant_dir ]; then
-    Rscript ${script_dir}/figure_setup/sync-salmon-output.R
+# Step 0: Prepare id map and download quant.sf files if they do not exist
+if [[ ! -d $salmon_quant_dir || ! -d $reference_dir ]]; then
+    Rscript ${script_dir}/figure_setup/prepare-data-files.R
 fi
 
 for project_dir in $salmon_quant_dir/*; do

--- a/analysis/bulk-deconvolution/run-deconvolution.sh
+++ b/analysis/bulk-deconvolution/run-deconvolution.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# This script runs this analysis and I will add more comments later.
+# If you are using 1P, you may need op run -- .
+
+set -euo pipefail
+
+# Run script from its location
+basedir=$(dirname "${BASH_SOURCE[0]}")
+cd "$basedir"
+
+# Define directories
+data_dir="data"
+script_dir="scripts"
+salmon_quant_dir="${data_dir}/salmon-quant-files"
+tpm_dir="${data_dir}/tpm"
+
+# Step 0: Download quant.sf files if they do not exist
+if [ ! -d $salmon_quant_dir ]; then
+    Rscript ${script_dir}/figure_setup/sync-salmon-output.R
+fi
+
+for project_dir in $salmon_quant_dir/*; do
+    project_id=$(basename $project_dir)
+
+    # Step 1: Calculate TPM for each project
+    Rscript ${script_dir}/calculate-tpm.R \
+        --project_id ${project_id} \
+        --output_dir ${tpm_dir}
+
+    # Step 2: Run quanTIseq on each project
+    # forthcoming!
+
+done
+

--- a/analysis/bulk-deconvolution/run-deconvolution.sh
+++ b/analysis/bulk-deconvolution/run-deconvolution.sh
@@ -15,10 +15,8 @@ salmon_quant_dir="${data_dir}/salmon-quant-files"
 reference_dir=${data_dir}/reference # stores the id map file
 tpm_dir="${data_dir}/tpm"
 
-# Step 0: Prepare id map and download quant.sf files if they do not exist
-if [[ ! -d $salmon_quant_dir || ! -d $reference_dir ]]; then
-    Rscript ${script_dir}/figure_setup/prepare-data-files.R
-fi
+# Step 0: Prepare id map and sync quant.sf files if they do not exist
+Rscript ${script_dir}/prepare-data-files.R
 
 for project_dir in $salmon_quant_dir/*; do
     project_id=$(basename $project_dir)

--- a/analysis/bulk-deconvolution/scripts/README.md
+++ b/analysis/bulk-deconvolution/scripts/README.md
@@ -7,3 +7,6 @@ This script saves all files in `../data/salmon-quant-files/<project id>/<sample 
    ```sh
    op run -- Rscript sync-salmon-output.R
    ```
+- `calculate-tpm.R`: This script creates a TSV of TPM values for all samples in a given project.
+Ensembl ids are also converted to gene symbols, where TPM values for duplicate gene symbols are summed.
+TSV files are exported to `../data/tpm/<project id>-tpm.tsv`.

--- a/analysis/bulk-deconvolution/scripts/README.md
+++ b/analysis/bulk-deconvolution/scripts/README.md
@@ -1,12 +1,15 @@
 This directory contains scripts used in the bulk deconvolution analysis.
 
-- `sync-salmon-output.R`: This script identifies solid tumor bulk libraries of interest and obtains their `quant.sf` files from S3.
-These files will be used to calculate TPM values as input to deconvolution.
-This script saves all files in `../data/salmon-quant-files/<project id>/<sample id>/<library id>`; note that the `data` directory is ignored by Git.
- - To run this script as a member of the Data Lab, you may need to preface with `op run --` if you are using 1Password to manage credentials:
-   ```sh
-   op run -- Rscript sync-salmon-output.R
-   ```
+- `prepare-data-files.R`: This script prepares some input data for analysis:
+  - First, it uses an ScPCA SCE to prepare and export a table mapping ensembl ids and gene symbols.
+  This table is saved in `../data/reference/ensembl_symbol.tsv`.
+  - Second, it identifies solid tumor bulk libraries of interest and obtains their `quant.sf` files from S3.
+  These files will be used to calculate TPM values as input to deconvolution.
+    - Files are saved in `../data/salmon-quant-files/<project id>/<sample id>/<library id>`.
+  - To run this script as a member of the Data Lab, you may need to preface with `op run --` if you are using 1Password to manage credentials:
+     ```sh
+     op run -- Rscript prepare-data-files.R
+     ```
 - `calculate-tpm.R`: This script creates a TSV of TPM values for all samples in a given project.
 Ensembl ids are also converted to gene symbols, where TPM values for duplicate gene symbols are summed.
 TSV files are exported to `../data/tpm/<project id>-tpm.tsv`.

--- a/analysis/bulk-deconvolution/scripts/calculate-tpm.R
+++ b/analysis/bulk-deconvolution/scripts/calculate-tpm.R
@@ -1,4 +1,4 @@
-# This script calculates a TPM matrix for salmon quant files from all samples in a given project and exports an RDS file named `<project_id>-tpm.tsv`.
+# This script calculates a TPM matrix for salmon quant files from all samples in a given project and exports an RDS file named `<project_id>-tpm.rds`.
 # Input quant files are expected to be stored as `project_id/sample_id/library_id/quant.sf` in the provided "input_dir" argument.
 # This file will have a column `gene_symbol` and a column for each sample.
 # As such, this script also converts ensembl ids to gene symbols, which is needed as input to deconvolution methods.
@@ -24,7 +24,7 @@ option_list <- list(
   make_option(
     "--output_dir",
     type = "character",
-    help = "Output directory to save TSV with TPM values."
+    help = "Output directory to save RDS with TPM values."
   ),
   make_option(
     "--t2g_file",
@@ -51,7 +51,7 @@ data_dir <- file.path(opts$input_dir, opts$project_id)
 stopifnot("Provided `input_dir` does not contain a directory with quant files for the specified `project_id`." = dir.exists(data_dir))
 
 fs::dir_create(opts$output_dir)
-output_file <- file.path(opts$output_dir, glue::glue("{opts$project_id}-tpm.tsv"))
+output_file <- file.path(opts$output_dir, glue::glue("{opts$project_id}-tpm.rds"))
 
 stopifnot("The t2g file could not be found." = file.exists(opts$t2g_file))
 stopifnot("The id mapping file to use for id mapping could not be found." = file.exists(opts$id_map_file))

--- a/analysis/bulk-deconvolution/scripts/calculate-tpm.R
+++ b/analysis/bulk-deconvolution/scripts/calculate-tpm.R
@@ -1,0 +1,142 @@
+# This script calculates TPM for salmon quant files from all samples in a given project and exports a TSV file named `<project_id>-tpm.tsv`.
+# Input quant files are expected to be stored as `project_id/sample_id/library_id/quant.sf` in the provided "input_dir" argument.
+# This file will have a column `gene_symbol` and a column for each sample.
+# As such, this script also converts ensembl ids to gene symbols, which is needed as input to deconvolution methods.
+
+renv::load()
+library(optparse)
+
+
+# Parse options --------
+option_list <- list(
+  make_option(
+    "--project_id",
+    type = "character",
+    default = "SCPCP000001",
+    help = "ScPCA project id to calculate TPM for."
+  ),
+  make_option(
+    "--input_dir",
+    type = "character",
+    default = here::here("analysis", "bulk-deconvolution", "data", "salmon-quant-files"),
+    help = "Input directory containing a project-specific directory with salmon quant files organized by sample/library."
+  ),
+  make_option(
+    "--output_dir",
+    type = "character",
+    help = "Output directory to save TSV with TPM values."
+  ), 
+  make_option(
+    "--t2g_file", 
+    type = "character", 
+    default = here::here("s3_files", "reference_files", "Homo_sapiens.GRCh38.104.spliced_cdna.tx2gene.tsv"), 
+    help = "Path to the t2g file used to read in quant.sf files."
+  ),
+  make_option(
+    "--scpca_sce_file", 
+    type = "character", 
+    default = here::here("s3_files", "SCPCS000001", "SCPCL000001_processed.rds"), 
+    help = "Path to an SCE file used to obtain mappings for converting ensembl ids to gene symbols."
+  )
+)
+opts <- parse_args(OptionParser(option_list = option_list))
+
+# Check inputs and define paths -------
+stopifnot(
+  "A project id in the format SCPCPXXXXXX must be provided to `project_id`." = !is.null(opts$project_id), 
+  "An output directory must be specified with `output_dir`." = !is.null(opts$output_dir)
+)
+
+data_dir <- file.path(opts$input_dir, opts$project_id)
+stopifnot("Provided `input_dir` does not contain a directory with quant files for the specified `project_id`." = dir.exists(data_dir))
+
+fs::dir_create(opts$output_dir)
+output_file <- file.path(opts$output_dir, glue::glue("{opts$project_id}-tpm.tsv"))
+  
+stopifnot("The t2g file could not be found." = file.exists(opts$t2g_file))
+stopifnot("The SCE file to use for id mapping could not be found." = file.exists(opts$scpca_sce_file))
+
+
+# Read input helper files -----------
+t2g_table <- readr::read_tsv(
+  opts$t2g_file, 
+  col_names = c("transcript_id", "gene_id"), 
+  show_col_types = FALSE
+)
+sce <- readRDS(opts$scpca_sce_file)
+map_table <- data.frame(
+  ensembl_id = SingleCellExperiment::rowData(sce)$gene_ids, 
+  gene_symbol = SingleCellExperiment::rowData(sce)$gene_symbol
+)
+
+
+# Find all quant.sf files -------------
+quant_files <- list.files(
+  path = data_dir, 
+  recursive = TRUE
+)
+stopifnot("Could not find any quant.sf files for the specified project." = length(quant_files) > 0)
+
+# Calculate TPM for each sample and combine into single data frame ---------
+tpm_df <- quant_files |>
+  purrr::map(
+    \(quant_file_path) {
+      
+      split_file <- stringr::str_split_1(quant_file_path, pattern = "/")
+      sample_id <- split_file[1]
+      library_id <- split_file[2]
+      
+      # read in with tximport and extract TPM
+      txi_salmon <- tximport::tximport(
+        file.path(data_dir, quant_file_path), 
+        type = "salmon", 
+        tx2gene = t2g_table
+      )
+      tpm <- txi_salmon$abundance[,1]
+      ensembl_ids <- names(tpm)
+      
+      # return data frame where the tpm column is named by the sample id
+      sample_tpm_df <- data.frame(tpm = tpm)
+      names(sample_tpm_df) <- sample_id
+      sample_tpm_df
+      
+    }
+  ) |>
+  # we expect the same genes all around here since quantification used the same gene set
+  dplyr::bind_cols() |>
+  tibble::rownames_to_column(var = "ensembl_id")
+
+
+
+# Convert ensembl ids to gene symbols and sum TPM for duplicate symbols ------
+tpm_symbols_df <- tpm_df |>
+  dplyr::left_join(map_table, by = "ensembl_id") |> 
+  # Remove any NA genes
+  tidyr::drop_na(gene_symbol) |>
+  # Combine duplicate gene symbols by summing
+  tidyr::pivot_longer(starts_with("SCPCS"), names_to = "sample_id", values_to = "tpm") |>
+  dplyr::group_by(sample_id, gene_symbol) |>
+  dplyr::summarize(tpm = sum(tpm)) |>
+  tidyr::pivot_wider(names_from = "sample_id", values_from = "tpm")
+
+
+# Export to tsv -------
+readr::write_tsv(tpm_symbols_df, output_file)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/analysis/bulk-deconvolution/scripts/calculate-tpm.R
+++ b/analysis/bulk-deconvolution/scripts/calculate-tpm.R
@@ -78,33 +78,18 @@ quant_files <- list.files(
 stopifnot("Could not find any quant.sf files for the specified project." = length(quant_files) > 0)
 
 # Calculate TPM for each sample and combine into single data frame ---------
-tpm_df <- quant_files |>
-  purrr::map(
-    \(quant_file_path) {
 
-      split_file <- stringr::str_split_1(quant_file_path, pattern = "/")
-      sample_id <- split_file[1]
-      library_id <- split_file[2]
+sample_ids <- stringr::str_split_i(quant_files, pattern = "/", i = 1)
+quant_paths <- setNames(file.path(data_dir, quant_files), sample_ids)
 
-      # read in with tximport and extract TPM
-      txi_salmon <- tximport::tximport(
-        file.path(data_dir, quant_file_path),
-        type = "salmon",
-        tx2gene = t2g_table
-      )
-      tpm <- txi_salmon$abundance[,1]
-      ensembl_ids <- names(tpm)
 
-      # return data frame where the tpm column is named by the sample id
-      sample_tpm_df <- data.frame(tpm = tpm)
-      names(sample_tpm_df) <- sample_id
-      sample_tpm_df
+txi_salmon <- tximport::tximport(
+  quant_paths,
+  type = "salmon",
+  tx2gene = t2g_table
+)
 
-    }
-  ) |>
-  # we expect the same genes all around here since quantification used the same gene set
-  dplyr::bind_cols() |>
-  tibble::rownames_to_column(var = "ensembl_id")
+tpm_mat  <- txi_salmon$abundance
 
 
 

--- a/analysis/bulk-deconvolution/scripts/prepare-data-files.R
+++ b/analysis/bulk-deconvolution/scripts/prepare-data-files.R
@@ -22,7 +22,6 @@ option_list <- list(
   )
 )
 opts <- parse_args(OptionParser(option_list = option_list))
-stopifnot("The SCE file to use for id mapping could not be found." = file.exists(opts$scpca_sce_file))
 
 
 # Define files and directories ---------
@@ -38,6 +37,7 @@ fs::dir_create(dirname(map_tsv_path))
 
 # First, export the TSV file for id mapping if it does not yet exist ------------------
 if (!file.exists(map_tsv_path)) {
+  stopifnot("The SCE file to use for id mapping could not be found." = file.exists(opts$scpca_sce_file))
   sce <- readRDS(opts$scpca_sce_file)
   map_table <- data.frame(
     ensembl_id = SingleCellExperiment::rowData(sce)$gene_ids,

--- a/analysis/bulk-deconvolution/scripts/prepare-data-files.R
+++ b/analysis/bulk-deconvolution/scripts/prepare-data-files.R
@@ -1,10 +1,30 @@
-# This script is used to download data needed for bulk solid tumor deconvolution analysis
-# All files will be saved in `../data/salmon-quant-files/<project id>/<sample id>/<library id>`
-# 
-# This script assumes that the ../../s3_files/scpca-<sample/library>-metadata.tsv files present. These files can be obtained with ../../scripts/figure_setup/sync-metadata.R.
+# This script prepares several data files for use in the bulk deconvolution anaylsis:
+# - Exports a table for ensembl/gene symbol id mapping to `../data/reference/ensembl_symbol.tsv`, based on an ScPCA SCE 
+# - Syncs all `quant.sf` files from S3 needed for bulk solid tumor deconvolution analysis to `../data/salmon-quant-files/<project id>/<sample id>/<library id>` 
+#
+# This script assumes that the following files are present in ../../s3_files/:
+# - reference_files/scpca-sample-metadata.tsv
+# - reference_files/scpca-library-metadata.tsv
+# - SCPCS000001/SCPCL000001_processed.rds
+# These files can be obtained with ../../scripts/figure_setup/sync-metadata.R and ../../scripts/figure_setup/sync-data-files.R
 
 renv::load()
+library(optparse)
 
+
+# Parse options --------
+option_list <- list(
+  make_option(
+    "--scpca_sce_file",
+    type = "character",
+    default = here::here("s3_files", "SCPCS000001", "SCPCL000001_processed.rds"),
+    help = "Path to an SCE file used to obtain mappings for converting ensembl ids to gene symbols."
+  )
+)
+opts <- parse_args(OptionParser(option_list = option_list))
+stopifnot("The SCE file to use for id mapping could not be found." = file.exists(opts$scpca_sce_file))
+
+  
 # Define files and directories ---------
 library_metadata_file <- here::here("s3_files", "scpca-library-metadata.tsv")
 sample_metadata_file <- here::here("s3_files", "scpca-sample-metadata.tsv")
@@ -12,6 +32,19 @@ bulk_dir <- here::here("analysis", "bulk-deconvolution")
 s3_path <- "s3://nextflow-ccdl-results/scpca-prod/checkpoints/salmon" #/library_id/quant.sf
 data_path <- file.path(bulk_dir, "data", "salmon-quant-files")
 fs::dir_create(data_path)
+
+map_tsv_path <- file.path(bulk_dir, "data", "reference", "ensembl_symbol.tsv") 
+fs::dir_create(dirname(map_tsv_path))
+
+# First, export the TSV file for id mapping ------------------
+sce <- readRDS(opts$scpca_sce_file)
+map_table <- data.frame(
+  ensembl_id = SingleCellExperiment::rowData(sce)$gene_ids,
+  gene_symbol = SingleCellExperiment::rowData(sce)$gene_symbol
+)
+readr::write_tsv(map_table, map_tsv_path)
+
+# Second, obtain the quant.sf files ------------------
 
 # Read in the metadata files and parse it for bulk samples of interest ---------
 # Parsing code adapted from: https://github.com/AlexsLemonade/scpca-paper-figures/issues/98#issuecomment-2573164429

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.3.1",
+    "Version": "4.3.3",
     "Repositories": [
       {
         "Name": "BioCsoft",
@@ -132,6 +132,7 @@
       "Package": "BiocVersion",
       "Version": "3.18.1",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.18",
       "Requirements": [
         "R"
       ],
@@ -399,11 +400,12 @@
     },
     "Matrix": {
       "Package": "Matrix",
-      "Version": "1.5-4.1",
+      "Version": "1.6-5",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "https://packagemanager.posit.co/cran/2024-04-26",
       "Requirements": [
         "R",
+        "grDevices",
         "graphics",
         "grid",
         "lattice",
@@ -411,7 +413,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "38082d362d317745fb932e13956dccbb"
+      "Hash": "8c7115cd3a0e048bda2a7cd110549f7a"
     },
     "MatrixGenerics": {
       "Package": "MatrixGenerics",
@@ -617,6 +619,7 @@
       "Package": "S4Vectors",
       "Version": "0.40.2",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.18",
       "Requirements": [
         "BiocGenerics",
         "R",
@@ -836,6 +839,7 @@
       "Package": "bluster",
       "Version": "1.12.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.18",
       "Requirements": [
         "BiocNeighbors",
         "BiocParallel",
@@ -1415,6 +1419,16 @@
         "methods"
       ],
       "Hash": "15e9634c0fcd294799e9b2e929ed1b86"
+    },
+    "getopt": {
+      "Package": "getopt",
+      "Version": "1.20.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "stats"
+      ],
+      "Hash": "ed33b16c6d24f7ced1d68877ac2509ee"
     },
     "ggbeeswarm": {
       "Package": "ggbeeswarm",
@@ -2006,6 +2020,18 @@
       ],
       "Hash": "df58958f293b166e4ab885ebcad90e02"
     },
+    "optparse": {
+      "Package": "optparse",
+      "Version": "1.7.5",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "getopt",
+        "methods"
+      ],
+      "Hash": "ce5f8381cd2c38d1fc14c83d8b21efd0"
+    },
     "patchwork": {
       "Package": "patchwork",
       "Version": "1.2.0",
@@ -2348,6 +2374,7 @@
       "Package": "rhdf5",
       "Version": "2.46.1",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.18",
       "Requirements": [
         "R",
         "Rhdf5lib",
@@ -2361,6 +2388,7 @@
       "Package": "rhdf5filters",
       "Version": "1.14.1",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.18",
       "Requirements": [
         "Rhdf5lib"
       ],
@@ -2501,8 +2529,8 @@
       "Package": "scpcaTools",
       "Version": "0.3.1",
       "Source": "GitHub",
-      "Remotes": "AlexsLemonade/scpcaData, immunogenomics/lisi@v1.0",
       "RemoteType": "github",
+      "Remotes": "AlexsLemonade/scpcaData, immunogenomics/lisi@v1.0",
       "RemoteHost": "api.github.com",
       "RemoteRepo": "scpcaTools",
       "RemoteUsername": "AlexsLemonade",

--- a/scripts/figure_setup/sync-reference-files.R
+++ b/scripts/figure_setup/sync-reference-files.R
@@ -3,19 +3,28 @@
 
 renv::load()
 
-# path to mito file 
-mito_s3 <- 's3://scpca-references/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.mitogenes.txt'
-
-# create a directory to store S3 files
+# create a directory to store S3 files ----------
 local_s3_dir <- here::here("s3_files", "reference_files")
 fs::dir_create(local_s3_dir)
 
-# Copy mito file
+
+# path on S3 to mito and t2g files -----
+annotation_s3 <- "s3://scpca-references/homo_sapiens/ensembl-104/annotation"
+
+# sync mito file -----
+mito_s3 <- file.path(annotation_s3, "Homo_sapiens.GRCh38.104.mitogenes.txt")
 local_mito_file <- file.path(local_s3_dir, "Homo_sapiens.GRCh38.104.mitogenes.txt")
 sync_call <- glue::glue("aws s3 cp '{mito_s3}' '{local_mito_file}'")
 system(sync_call)
 
-# sync SingleR models 
+# sync t2g file -----
+t2g_s3 <- file.path(annotation_s3, "Homo_sapiens.GRCh38.104.spliced_cdna.tx2gene.tsv")
+local_t2g_file <- file.path(local_s3_dir, "Homo_sapiens.GRCh38.104.spliced_cdna.tx2gene.tsv")
+sync_call <- glue::glue("aws s3 cp '{t2g_s3}' '{local_t2g_file}'")
+system(sync_call)
+
+
+# sync SingleR models  ---------
 singler_s3_dir <- "s3://scpca-references/celltype/singler_models"
 singler_local_dir <- here::here("s3_files", "reference_files", "singler_models")
 

--- a/scripts/figure_setup/sync-reference-files.R
+++ b/scripts/figure_setup/sync-reference-files.R
@@ -13,20 +13,17 @@ annotation_s3 <- "s3://scpca-references/homo_sapiens/ensembl-104/annotation"
 
 # sync mito file -----
 mito_s3 <- file.path(annotation_s3, "Homo_sapiens.GRCh38.104.mitogenes.txt")
-local_mito_file <- file.path(local_s3_dir, "Homo_sapiens.GRCh38.104.mitogenes.txt")
-sync_call <- glue::glue("aws s3 cp '{mito_s3}' '{local_mito_file}'")
+sync_call <- glue::glue("aws s3 cp '{mito_s3}' '{local_s3_dir}'")
 system(sync_call)
 
 # sync t2g file -----
 t2g_s3 <- file.path(annotation_s3, "Homo_sapiens.GRCh38.104.spliced_cdna.tx2gene.tsv")
-local_t2g_file <- file.path(local_s3_dir, "Homo_sapiens.GRCh38.104.spliced_cdna.tx2gene.tsv")
-sync_call <- glue::glue("aws s3 cp '{t2g_s3}' '{local_t2g_file}'")
+sync_call <- glue::glue("aws s3 cp '{t2g_s3}' '{local_s3_dir}'")
 system(sync_call)
 
 
 # sync SingleR models  ---------
 singler_s3_dir <- "s3://scpca-references/celltype/singler_models"
 singler_local_dir <- here::here("s3_files", "reference_files", "singler_models")
-
 sync_call <- glue::glue("aws s3 cp '{singler_s3_dir}' '{singler_local_dir}' --recursive")
 system(sync_call)


### PR DESCRIPTION
Closes #99 

This PR adds two scripts:
- A script to calculate TPM for a given project and export a TSV file of results
  - I use an SCE to help id mapping, and I sum the duplicates as discussed. I use tidyverse and export a tsv here, but there's a good argument to use base R and matrices instead, especially since we'll have to convert these to matrices anyways! But, I enjoy tidyverse so that's what I did. Let me know if we prefer I change that.
  - A shell script for the analysis itself
    - This currently has a step with a _minimal check_ to download the `quant.sf` files - should this check be more involved? 
    - And then, we loop over project directories to calculate a TPM matrix for each. Next up is actual deconvolution.

There are several other updates:
- I updated readmes
- I updated `scripts/figure_setup/sync-reference-files.R` to also download the t2g file, since this script was doing those sorts of things anyways! I can move this sync into the deconvolution directory if preferred, though.
- I did have to get `optparse` into `renv`, so along the way that was indeed bumped to 1.0.5 which seemed not bad? I also saw this message go by: 
```
The following package(s) have unsatisfied dependencies:
- MatrixModels requires Matrix (>= 1.6-0), but version 1.5-4.1 is installed
Consider updating the required dependencies as appropriate.
```
So, I went ahead and bumped just that package. 