### PR TITLE
Calculate and compare pseudobulk measures

### DIFF
--- a/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/README.md
+++ b/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/README.md
@@ -1,0 +1,3 @@
+This directory contains exploratory notebook that are not directly used in the analysis pipeline.
+
+* `pseudobulk-calculations.Rmd`: Compares options for calculating pseudobulk by visualization and comparison to corresponding bulk TPM

--- a/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/README.md
+++ b/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/README.md
@@ -1,3 +1,3 @@
 This directory contains exploratory notebook that are not directly used in the analysis pipeline.
 
-* `pseudobulk-calculations.Rmd`: Compares options for calculating pseudobulk by visualization and comparison to corresponding bulk TPM
+* `pseudobulk-calculations.Rmd`: Compares options for calculating pseudobulk by visualization and comparison to corresponding bulk TPM and normalized bulk counts

--- a/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/README.md
+++ b/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/README.md
@@ -1,3 +1,3 @@
 This directory contains exploratory notebook that are not directly used in the analysis pipeline.
 
-* `pseudobulk-calculations.Rmd`: Compares options for calculating pseudobulk by visualization and comparison to corresponding bulk TPM and normalized bulk counts
+* `pseudobulk-calculations.Rmd`: Compares different approaches of calculating pseudobulk and bulk expression

--- a/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
+++ b/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
@@ -237,13 +237,14 @@ make_binned_scatterplots(
 
 Points are fairly evenly distributed across the scatterplot, except for a very high concentration of points at `0,0` (and into the negatives for `pseudobulk_deseq`). 
 
+
 ### Statistics 
 
-Let's now get some stats for each sample.
+Let's now get some stats for the comparison between bulk and pseudobulk.
 We'll fit a linear model for each sample, and display some quantities below both as boxplots and the full table.
 
 ```{r fig.height = 10, fig.width = 12}
-
+# Helper function to plot model statistics from data frame
 plot_stats <- function(df, column, title) {
   ggplot(df) + 
     aes(x = expression_type, y = {{column}}, color = expression_type) + 
@@ -260,18 +261,18 @@ model_samples <- function(id, df) {
   
   df_deseq <- sample_df |>
     dplyr::filter(is.finite(pseudobulk_deseq), is.finite(bulk_tpm))
-  fit_deseq <- lm(bulk_tpm ~ pseudobulk_deseq, data = df_deseq) 
+  fit_deseq <- summary(lm(bulk_tpm ~ pseudobulk_deseq, data = df_deseq))
 
   df_log_counts <- sample_df |>
       dplyr::filter(is.finite(pseudobulk_log_counts), is.finite(bulk_tpm))
-  fit_log_counts <- lm(bulk_tpm ~ pseudobulk_log_counts, data = df_log_counts)
+  fit_log_counts <- summary(lm(bulk_tpm ~ pseudobulk_log_counts, data = df_log_counts))
       
   # Tabulate and return some fit stats
   data.frame(
     expression_type = c("deseq", "log_counts"),
-    rsquared = c(broom::glance(fit_deseq)$r.squared, broom::glance(fit_log_counts)$r.squared), 
-    coeff = c(broom::tidy(fit_deseq)$estimate[2], broom::tidy(fit_log_counts)$estimate[2]), 
-    residual_sd = c(broom::glance(fit_deseq)$sigma, broom::glance(fit_log_counts)$sigma)
+    rsquared = c(fit_deseq$r.squared, fit_log_counts$r.squared), 
+    coeff = c(fit_deseq$coefficients[2], fit_log_counts$coefficients[2]), 
+    residual_sd = c(fit_deseq$sigma,  fit_log_counts$sigma)
   )
 }
 
@@ -300,14 +301,11 @@ patchwork::wrap_plots(
   plot_stats(stats_df, residual_sd, "residual_sd"), 
   nrow = 3
 ) 
-
-
-
 ```
 
-* Pseudobulk quantities are mostly similar, and `pseudobolk_deseq` tends to outperform `pseudobolk_log_counts` for all projects except `SCPCP000009`, but notably there are only 3 samples for this project
-* Correlations are mostly zero or very low for `SCPCP000017`, and `SCPCP000001` and `SCPCP000002` show the strongest relationships overall
-
+* Pseudobulk quantities are exceptionally similar here, which isn't necessarily surprising given the similarity of the pseudobulk measures
+* Relationships are strongest for`SCPCP000001` and `SCPCP000002`, then `SCPCP000006`, and finally `SCPCP000009` and `SCPCP000017`, although `SCPCP00001`, `SCPCP000002`, and `SCPCP000006` do have higher residual sd.
+* Samples within a given project have broadly similar coefficients, with a few outliers, suggesting less of an interaction among samples/expression than one might have thought (although how much do the zeros drive this?)
 
 All the actual values are here:
 
@@ -315,8 +313,6 @@ All the actual values are here:
 ```{r}
 stats_df
 ```
-
-
 
 
 ## Session info

--- a/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
+++ b/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
@@ -1,0 +1,383 @@
+---
+title: "Pseudobulk and bulk data distributions"
+author: Stephanie J. Spielman
+date: "`r Sys.Date()`"
+output:
+  html_notebook:
+    toc: true
+    toc_depth: 3
+    code_folding: show
+---
+
+The goal of this notebook is to compare pseudobulk and bulk calculations to determine which pseudobulk calculation should we proceed with for modeling: the sum of logcounts (`pseudobulk_logcounts`) or the `DESeq2`-normalized sum of raw counts (`pseudobulk_deseq`).
+To this end, we'll visualize expression distributions, both on their own and compared to bulk TPM. 
+
+
+
+## Setup
+
+```{r setup}
+renv::load()
+
+library(ggplot2)
+theme_set(theme_bw())
+```
+
+### Paths
+
+```{r paths}
+data_dir <- here::here("analysis", "pseudobulk-bulk-prediction", "data")
+tpm_dir <- file.path(data_dir, "tpm")
+pseudobulk_dir <- file.path(data_dir, "pseudobulk")
+
+
+tpm_files <- list.files(
+  path = tpm_dir,
+  full.names = TRUE,
+  pattern = "*-tpm.tsv$"
+)
+tpm_names <- stringr::str_split_i(basename(tpm_files), pattern = "-", i = 1)
+names(tpm_files) <- tpm_names
+
+
+pseudobulk_files <- list.files(
+  path = pseudobulk_dir,
+  full.names = TRUE,
+  pattern = "*-pseudobulk.rds$"
+)
+pseudobulk_names <- stringr::str_split_i(basename(pseudobulk_files), pattern = "-", i = 1)
+names(pseudobulk_files) <- pseudobulk_names
+
+# Make sure we have the same projects, in the same order
+stopifnot(
+  all.equal(names(tpm_files), names(pseudobulk_files))
+)
+```
+
+### Read and prepare input data
+
+
+Data are saved as matrices, so we'll convert them to per-project long data frames here. 
+
+```{r}
+tpm_df_list <- tpm_files |>
+  purrr::map(
+    \(tpm_file) {
+      readr::read_tsv(tpm_file, show_col_types = FALSE) |>
+        tidyr::pivot_longer(
+          -ensembl_id, 
+          names_to = "sample_id", 
+          values_to = "expression"
+        ) |>
+        dplyr::mutate(expression_type = "bulk_tpm")   
+   }
+  )
+
+project_df_list <- purrr::map2(
+  pseudobulk_files, 
+  tpm_df_list,
+  \(pseudo_file, tpm_df) {
+    
+    pseudo_list <- readr::read_rds(pseudo_file)
+    
+    # Filter tpm_df for genes in the pseudobulk
+    tpm_filtered_df <- tpm_df |>
+      dplyr::filter(ensembl_id %in% rownames(pseudo_list[[1]]))
+      
+    # combine pseudobulk matrices into a long data frame and bind with tpm
+    combined_df_long <- pseudo_list |>
+      purrr::map(
+        \(mat) {
+          mat |>
+            as.data.frame() |> 
+            tibble::rownames_to_column("ensembl_id") |> 
+            tidyr::pivot_longer(
+              -ensembl_id, 
+              names_to = "sample_id", 
+              values_to = "expression"
+            )
+        }
+      ) |>
+      purrr::list_rbind(names_to = "expression_type") |> 
+      dplyr::bind_rows(tpm_filtered_df) |>
+      dplyr::select(sample_id, ensembl_id, expression, expression_type)
+  }
+)
+
+shared_genes <- purrr::map(
+  project_df_list, 
+  \(df) df$ensembl_id
+)
+
+tpm_df_indicator_list <- purrr::map2(
+  tpm_df_list,
+  shared_genes,
+  \(df, ids) dplyr::mutate(df, in_pseudo = ensembl_id %in% ids)
+  )
+
+# clean up!
+rm(shared_genes)
+rm(tpm_df_list)
+```
+
+
+
+## Bulk TPM distributions
+
+When establishing pseudobulk datasets, genes with low expression levels were removed. 
+
+Before looking at pseudobulk measures here, we'll look at how the TPM distributions (log2) compared between for genes that are and are not included in the pseudobulk datasets. the comparisons.
+We expect to see that genes not included in the pseudobulk have lower TPM.
+
+
+```{r, fig.width = 12,  fig.height = 4, warning=FALSE}
+tpm_df_indicator_list |>
+  purrr::imap(
+    \(df, project_id) {
+      
+      ggplot(df) + 
+        aes(x = log2(expression), fill = in_pseudo) + 
+        geom_density(alpha = 0.5) + 
+        labs(
+          title = project_id, 
+          x = "log2 bulk TPM"
+        ) +
+        theme(legend.position = "bottom")
+    }
+  ) |>
+  patchwork::wrap_plots(guides = "collect", nrow = 1) & theme(legend.position = "bottom")
+
+
+```
+
+We mostly see the expected trend: Genes included in the pseudobulk counts have higher expression in bulk compared to genes which were removed.
+`SCPCP000009` is an exception here, but this project has fewer samples compared to the rest so this could be a power artifact:
+
+```{r}
+tpm_df_indicator_list |>
+  purrr::map(
+    \(df) length(unique(df$sample_id))
+  )
+```
+
+Pause to clean up a little!
+
+```{r}
+rm(tpm_df_indicator_list)
+```
+
+
+## Distributions of pseudobulk
+
+
+First, let's get a general sense of the scale of values in the pseudobulk quantities:
+
+
+```{r}
+## logcounts
+project_df_list |>
+  purrr::map(
+    \(df) {
+      df |> 
+        dplyr::filter(expression_type == "pseudobulk_logcounts") |>
+        dplyr::pull(expression) |> 
+        summary()
+  })
+```
+
+
+```{r}
+## deseq
+project_df_list |>
+  purrr::map(
+    \(df) {
+      df |> 
+        dplyr::filter(expression_type == "pseudobulk_deseq") |>
+        dplyr::pull(expression) |> 
+        summary()
+  })
+```
+
+The logcounts version has some strong right-skew, so we should log those values to support modeling. 
+We don't see the same level of skew from DESeq, which is good since we don't expect to see it out of that normalization procedure; we don't need to transform those.
+
+Let's therefore update expression to be log2 for both TPM and pseudobulk logcounts (i.e., for all but pseudobulk deseq) since we'll use those scales moving forward:
+
+```{r warning = FALSE}
+project_df_list <- project_df_list |>
+  purrr::map(
+    \(df) {
+        df |>
+          dplyr::mutate(expression = ifelse(
+            stringr::str_detect(expression_type, "deseq"),
+            expression,
+            log2(expression) # TODO: do we want a fudge here?
+          ))
+    }
+  )
+```
+
+Now, we can visualize distributions of all quantities:
+
+```{r, fig.width = 12, fig.height = 8}
+project_df_list |>
+  purrr::imap(
+    \(df, project_id) {
+      
+     ggplot(df) + 
+        aes(x = expression, fill = expression_type) + 
+        geom_density(alpha = 0.5) + 
+        scale_fill_brewer(palette = "Dark2") + 
+        facet_wrap(vars(expression_type), scales = "free", nrow = 3) +
+        ggtitle(project_id) +
+        theme(legend.position = "none")
+    }
+  ) |>
+  patchwork::wrap_plots(guides = "collect", nrow = 1)
+```
+
+Both the pseudobulk distributions look reasonable enough!
+
+
+## Relationship between quantities
+
+Now come the many plots: What does the relationship look like between bulk and each flavor of pseudobulk?
+We'll visualize this per sample.
+
+We'll first make a pivoted version of this data to enable plotting and modeling.
+
+
+```{r}
+project_df_wide_list <- project_df_list |>
+  purrr::imap(
+    \(df, project_id) {
+       df |> 
+        tidyr::pivot_wider(
+          names_from = expression_type, 
+          values_from = expression
+        )
+    })
+```
+
+
+Next, we have many plots, organized by project:
+
+* Left-side panels are `bulk tpm ~ deseq pseudocounts`
+* Center panels are `bulk tpm ~ logcounts pseudocounts`
+* Right-side panels are `deseq pseudocounts ~ logcounts pseudocounts`, to assess their similarity directly
+
+```{r fig.height=30, fig.width=18, message=FALSE, warning=FALSE}
+project_df_wide_list |>
+  purrr::imap(
+    \(df, project_id) {
+      
+      p1 <- ggplot(df) + 
+        aes(x = pseudobulk_deseq, y = bulk_tpm) + 
+        geom_point(alpha = 0.2, size = 0.5) + 
+        geom_smooth(method = "lm") + 
+        facet_wrap(vars(sample_id), nrow = 5) +
+        ggtitle("bulk tpm ~ deseq")
+      
+      p2 <- ggplot(df) + 
+        aes(x = pseudobulk_logcounts, y = bulk_tpm) + 
+        geom_point(alpha = 0.2, size = 0.5) + 
+        geom_smooth(method = "lm") +
+        facet_wrap(vars(sample_id), nrow = 5) +
+        ggtitle("bulk tpm ~ logcounts") 
+      
+       p3 <- ggplot(df) + 
+        aes(x = pseudobulk_logcounts, y = pseudobulk_deseq) + 
+        geom_point(alpha = 0.2, size = 0.5) + 
+        geom_smooth(method = "lm") +
+        facet_wrap(vars(sample_id), nrow = 5) +
+        ggtitle("deseq ~ logcounts") 
+           
+      
+      patchwork::wrap_plots(p1, p2, p3) 
+
+    }
+  ) |>
+  patchwork::wrap_plots(nrow = 5)
+```
+
+On the whole, the relationship between bulk and pseudobulk look exceptionally similar regardless of which pseudobulk quantity is used!
+On the right-side, we see that indeed the pseudobulk versions are highly similar to one another (right-side panels).
+The main difference we can pick out from these plots is that the `logcounts` version has a band of lowly-expressed genes which the `deseq` version doesn't appear to show, which again is consistent with their different origins.
+
+
+To identify if there's a meaningful benefit to using one pseudobulk version over another, we'll build linear models of `tpm ~ pseudobulk * sample`; we can assume an interaction based on the slopes in the above scatterplots.
+Note that these are not final models for analysis, but only used to guide our next steps of actually building/fine-tuning the models.
+
+We'll also have a look at the distributions of model residuals along the way.
+
+```{r fig.height = 2, fig.width = 5}
+project_df_wide_list |>
+  purrr::map(
+    \(df) {
+      
+      # Build models
+      # We first need to remove any undefined values for each model
+      df_deseq <- df |>
+        dplyr::filter(is.finite(pseudobulk_deseq), is.finite(bulk_tpm))
+      fit_deseq <- lm(bulk_tpm ~ pseudobulk_deseq * sample_id, data = df_deseq)
+    
+      df_logcounts <- df |>
+        dplyr::filter(is.finite(pseudobulk_logcounts), is.finite(bulk_tpm))
+      fit_logcounts <- lm(bulk_tpm ~ pseudobulk_logcounts * sample_id, data = df_logcounts)
+      
+      # Tabulate some fit stats
+      fit_table <- tibble::tribble(
+        ~expression_type, ~rsquared, ~residual_sd, 
+        "deseq", broom::glance(fit_deseq)$r.squared, broom::glance(fit_deseq)$sigma, 
+        "logcounts", broom::glance(fit_logcounts)$r.squared, broom::glance(fit_logcounts)$sigma
+      )
+      
+      
+      # Tabulate some fit stats, wide for easier viewing
+      broom_deseq <- broom::glance(fit_deseq)
+      broom_logcounts <- broom::glance(fit_logcounts)
+      fit_table <- data.frame(
+        deseq_rsquared        = broom_deseq$r.squared,
+        logcounts_rsquared    = broom_logcounts$r.squared,
+        deseq_residual_sd     = broom_deseq$sigma,
+        logcounts_residual_sd = broom_logcounts$sigma    
+      )
+      
+      # Plot the residuals as well on the way down
+      deseq_augment <- broom::augment(fit_deseq)
+      logcounts_augment <- broom::augment(fit_logcounts)
+      
+      p1 <- ggplot(deseq_augment) + 
+        aes(x = pseudobulk_deseq, y = .resid) + 
+        geom_point(size = 0.5, alpha = 0.5) + 
+        geom_hline(yintercept = 0, color = "red") +
+        ggtitle("deseq")
+      p2 <- ggplot(logcounts_augment) + 
+        aes(x = pseudobulk_logcounts, y = .resid) + 
+        geom_point(size = 0.5, alpha = 0.5) + 
+        geom_hline(yintercept = 0, color = "red") +
+        ggtitle("logcounts")
+      
+      print(patchwork::wrap_plots(p1, p2, nrow = 1))
+      
+      # actually return the fit info
+      fit_table
+      
+    }
+) |>
+  purrr::list_rbind(names_to = "project_id")
+```
+
+Models from different pseudobulk quantities are expectedly, based on scatterplots above,  minimal, and based on the residual plots around linear model assumptions seem reasonably met.
+The `DESeq2` flavor appears to marginally outperform (based on these limited stats) in 3/5 projects. 
+
+## Conclusions
+
+Either calculation for pseudobulk appears to be fine, and it's likely that we'd get roughly the same results either way.
+I would suggest to proceed with the `DESeq2` normalized version since we do not need additional `log2` transformations, which leads to loss of 0-expression genes in the model since they are undefined (unless we want to fudge factor them, but avoiding this if we can seems best).
+
+## Session info
+
+```{r}
+sessionInfo()
+```

--- a/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
+++ b/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
@@ -255,19 +255,16 @@ Some of these genes actually have decent values in single-cell.
 Here, we visualize distributions of all quantities:
 
 ```{r, fig.width = 12, fig.height = 8, warning = FALSE}
-project_long_df_list |>
-  purrr::imap(
-    \(df, project_id) {
-       ggplot(df) + 
-          aes(x = expression, fill = expression_type) + 
-          geom_density(alpha = 0.5) + 
-          scale_fill_brewer(palette = "Dark2") + 
-          facet_wrap(vars(expression_type), scales = "free", nrow = 4) +
-          ggtitle(project_id) +
-          theme(legend.position = "none")
-    }
-  ) |>
-  patchwork::wrap_plots(guides = "collect", nrow = 1)
+ggplot(purrr::list_rbind(project_long_df_list, names_to = "project_id")) + 
+  aes(x = expression, fill = expression_type) + 
+  geom_density(alpha = 0.5) + 
+  scale_fill_brewer(palette = "Dark2") + 
+  facet_grid(
+    rows = vars(expression_type), 
+    cols = vars(project_id),
+    scales = "free_y"
+  ) +
+  theme(legend.position = "none")
 ```
 
 
@@ -314,7 +311,7 @@ project_wide_df_list |>
 
     }
   ) |>
-  patchwork::wrap_plots(nrow = 5)
+  patchwork::wrap_plots(ncol = 1)
 ```
 
 

--- a/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
+++ b/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
@@ -187,69 +187,6 @@ project_wide_df_list |>
 Indeed, `pseudobulk_log_counts` is never finite (aka, it is always `-Inf`) when `pseudobulk_deseq` is 0, which is good to know.
 
 
-Let's also check if we have the same genes between bulk and single-cell.
-Any genes present in one modality but not the other will have `NA` expression (transforming any 0 expressions will have produced `-Inf`, not `NA`, so those `NA`s are from joining).
-
-Are any in single-cell but not bulk?
-```{r}
-project_wide_df_list |>
-  purrr::map(\(df){
-    df |> 
-      dplyr::filter(!is.na(bulk_tpm), 
-                    is.na(pseudobulk_deseq), 
-                    is.na(pseudobulk_log_counts)) 
-  }) |>
-  dplyr::bind_rows()
-
-```
-Nope! How about single-cell but not bulk?
-```{r}
-only_single_cell <- project_wide_df_list |>
-  purrr::map(\(df){
-    df |> 
-      dplyr::filter(is.na(bulk_tpm), 
-                    !is.na(pseudobulk_deseq), 
-                    !is.na(pseudobulk_log_counts)) 
-  }) |>
-  purrr::list_rbind(names_to = "project_id") |>
-  dplyr::count(project_id, ensembl_id)
-only_single_cell
-```
-
-
-Yup!
-Plus, these numbers are all the sample numbers...
-
-```{r}
-only_single_cell |>
-  dplyr::count(ensembl_id)
-```
-..and it's the same genes all round (probably a reference thing...?).
-
-
-In any case, what is the expression of these genes in pseudobulk?
-```{r fig.height=3, fig.width=8}
-genes_not_in_bulk <- project_wide_df_list |>
-  purrr::map(
-  \(df) df |> dplyr::filter(is.na(bulk_tpm)) 
-) |>
-  purrr::list_rbind(names_to = "project_id") |>
-  dplyr::select(-bulk_tpm) |>
-  tidyr::pivot_longer(
-    contains("pseudobulk"), 
-    names_to = "expression_type", 
-    values_to = "expression"
-  )
-
-ggplot(genes_not_in_bulk) + 
-  aes(x = expression_type, y = expression) +
-  geom_boxplot() + 
-  facet_wrap(vars(project_id), nrow = 1) +
-  theme(axis.text.x = element_text(angle = 30, hjust = 1))
-```
-Some of these genes actually have decent values in single-cell.
-
-
 ### Full distributions
 
 Here, we visualize distributions of all quantities:

--- a/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
+++ b/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
@@ -84,114 +84,11 @@ project_wide_df_list <- project_long_df_list |>
 ```
 
 
-## Distributions of expression values
+## Full distributions
 
+First, we'll visualize distributions of all quantities:
 
-First, let's get a general sense of the scale of values in the pseudobulk quantities:
-
-```{r}
-project_wide_df_list |>
-  purrr::map(
-    \(df) {
-      df |>
-        # consider only genes with values not lost to transformation
-        dplyr::filter(is.finite(pseudobulk_log_counts)) |>
-        dplyr::pull(pseudobulk_log_counts) |>
-        summary()
-    }
-  )
-```
-
-
-```{r}
-project_wide_df_list |>
-  purrr::map(
-    \(df) summary(df$pseudobulk_deseq)
-  )
-```
-
-
-
-Due to the different transformation approaches, the `pseudobulk_deseq` version has some negatives for fractional values, but `pseudobulk_log_counts` has a lower bound of 0.
-These different scales of data are important to keep in mind.
-
-
-### Undefined values
-
-Due to the `log2` transformation and sparsity of scRNA-seq counts, many values in `pseudobulk_log_counts` are expected to be `-Inf`, aka essentially unobserved in the single-cell data.
-We'll look at histograms, per project, of the percentage of genes with _defined_:
-
-```{r fig.height = 3, fig.width = 8}
-finite_df <- project_wide_df_list |>
-  purrr::map(
-    \(df) {
-      df |>
-        dplyr::count(sample_id, is_finite = is.finite(pseudobulk_log_counts)) |>
-        tidyr::pivot_wider(
-          names_from = is_finite, 
-          values_from = n, 
-          names_prefix = "finite_",
-          values_fill = 0
-        ) |>
-        dplyr::mutate(percent_genes_with_expression = finite_TRUE/(finite_FALSE + finite_TRUE))
-    }) |>
-  purrr::list_rbind(names_to = "project_id")
-
-
-ggplot(finite_df) +
-  aes(x = percent_genes_with_expression, fill = project_id) + 
-  geom_histogram(bins = 15) + 
-  facet_wrap(vars(project_id), nrow = 1) + 
-  theme(legend.position = "none")
-```
-It looks like about half the genes, but ranging from ~20 - 60\%, of genes in a given sample are non-zero.
-This means about 40-80\% of genes in the genome are not observed per sample.
-
-
-What are the `pseudobulk_deseq` values where the `pseudobulk_log_counts` values (above) are `-Inf`?
-
-```{r fig.height = 3, fig.width = 8}
-deseq_inf_df <- project_wide_df_list |>
-  purrr::map(
-    \(df) dplyr::filter(df, is.infinite(pseudobulk_log_counts))
-  )|>
-  purrr::list_rbind(names_to = "project_id")
-
-
-ggplot(deseq_inf_df) +
-  aes(x = pseudobulk_deseq, fill = project_id) + 
-  geom_histogram(bins = 15) + 
-  facet_wrap(vars(project_id), nrow = 1) + 
-  theme(legend.position = "none")
-```
-
-So, lots of the 0s are here which we expect to see.
-Are _all_ the 0s here?
-
-If all the 0s are the same as all the infinites, then there should be no rows where 0 and finite co-occur:
-
-
-```{r}
-project_wide_df_list |>
-  purrr::map(
-    \(df) {
-      df |>
-        # when deseq is 0, is log_counts always -inf?
-        dplyr::filter(
-          pseudobulk_deseq == 0, 
-          is.finite(pseudobulk_log_counts)
-        ) |>
-        nrow()
-  })
-```
-Indeed, `pseudobulk_log_counts` is never finite (aka, it is always `-Inf`) when `pseudobulk_deseq` is 0, which is good to know.
-
-
-### Full distributions
-
-Here, we visualize distributions of all quantities:
-
-```{r, fig.width = 12, fig.height = 8, warning = FALSE}
+```{r, fig.width = 7, fig.height = 5, warning = FALSE}
 ggplot(purrr::list_rbind(project_long_df_list, names_to = "project_id")) + 
   aes(x = expression, fill = expression_type) + 
   geom_density(alpha = 0.5) + 
@@ -204,7 +101,10 @@ ggplot(purrr::list_rbind(project_long_df_list, names_to = "project_id")) +
   theme(legend.position = "none")
 ```
 
-
+We see big spikes at zero, not surprisingly.
+Due to the different transformation approaches, the `pseudobulk_deseq` version has some negatives for fractional values, but the other quantities have a lower bound of zero.
+Bulk TPM has the highest peak at zero by a good amount, followed by `pseudobulk_log_counts` and then `pseudobulk_deseq`.
+All around distribution range from their lower bound up to around 20.
 
 ## Relationship between quantities
 

--- a/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
+++ b/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
@@ -103,19 +103,8 @@ ggplot(purrr::list_rbind(project_long_df_list, names_to = "project_id")) +
 
 We see big spikes at zero for pseudobulk, not surprisingly.
 Due to the different transformation approaches, the `pseudobulk_deseq` version has some negatives for fractional values, but the other quantities have a lower bound of zero.
-Bulk TPM has the highest peak at zero by a good amount, followed by `pseudobulk_log_counts` and then `pseudobulk_deseq`.
 All around, distributions range from their lower bound up to around 20, so it's nice to know pseudobulk and bulk are definitely on the same scale.
 
-## Relationship between quantities
-
-
-This section will look at the relationship between bulk and pseudobulk quantities with:
-
-* scatterplots to confirm if we have a linear relationship
-* per-sample linear models of `bulk ~ pseudobulk` to do a cursory comparison of model statistics
-  * these results are presented both as plots and as the full per-sample table to scroll through
-  
-  
   
 ## Relationship between quantities
 
@@ -134,7 +123,7 @@ In all plots, the red line is `y=x`, and the blue line is the regression line.
 
 #### Compare pseudobulk measures
 
-```{r fig.height=28, fig.width=12, message=FALSE, warning=FALSE}
+```{r fig.height=34, fig.width=8, message=FALSE, warning=FALSE}
 project_wide_df_list |>
   purrr::imap(
     \(df, project_id) {
@@ -145,7 +134,7 @@ project_wide_df_list |>
         geom_smooth(method = "lm", linewidth = 0.5) +
         geom_abline(linewidth = 0.5, color = "red") + 
         facet_wrap(vars(sample_id), nrow = 5) +
-        ggtitle("log_counts ~ deseq") 
+        ggtitle(project_id) 
 
     }
   ) |>
@@ -156,7 +145,7 @@ project_wide_df_list |>
 These quantities are exceptionally similar with these differences:
 
 * Driven by different normalization approaches, genes with very low to zero expression
-* In a handful of sampels (1-2 per project), `pseudobulk_log_counts` appears to have a higher proportion of low to zero counts, and throughout has markedly lower values compares to `pseudobulk_deseq`.
+* In a handful of samples (1-2 per project), `pseudobulk_log_counts` appears to have a higher proportion of low to zero counts, and throughout has lower values than `pseudobulk_deseq`.
 
 
 #### Compare pseudobulk to bulk

--- a/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
+++ b/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
@@ -6,7 +6,7 @@ output:
   html_notebook:
     toc: true
     toc_depth: 3
-    code_folding: show
+    code_folding: hide
 ---
 
 The goal of this notebook is to compare pseudobulk and bulk calculations to determine which pseudobulk calculation should we proceed with for modeling: the log2 of the sum of raw counts (`pseudobulk_log_counts`) or the `DESeq2`-normalized sum of raw counts (`pseudobulk_deseq`).
@@ -67,7 +67,7 @@ project_long_df_list <- purrr::map2(
     dplyr::bind_rows(
       # TPM needs to be in log2 space
       readr::read_tsv(tpm_file, show_col_types = FALSE) |>
-        dplyr::mutate(expression = log2(expression)),
+        dplyr::mutate(expression = log2(expression)), 
       readr::read_tsv(pseudo_file, show_col_types = FALSE)
     )
   }
@@ -101,10 +101,10 @@ ggplot(purrr::list_rbind(project_long_df_list, names_to = "project_id")) +
   theme(legend.position = "none")
 ```
 
-We see big spikes at zero, not surprisingly.
+We see big spikes at zero for pseudobulk, not surprisingly.
 Due to the different transformation approaches, the `pseudobulk_deseq` version has some negatives for fractional values, but the other quantities have a lower bound of zero.
 Bulk TPM has the highest peak at zero by a good amount, followed by `pseudobulk_log_counts` and then `pseudobulk_deseq`.
-All around distribution range from their lower bound up to around 20.
+All around, distributions range from their lower bound up to around 20, so it's nice to know pseudobulk and bulk are definitely on the same scale.
 
 ## Relationship between quantities
 
@@ -165,10 +165,10 @@ To make sure we get a good view, we'll first make the plots and then show them p
 
 ```{r}
 # Helper function to visualize scatterplots with geom_bin_2d()
-make_binned_scatterplots <- function(df, project_id, facet_rows) {
+make_binned_scatterplots <- function(df, project_id, nbins, facet_rows) {
   p1 <- ggplot(df) + 
     aes(x = pseudobulk_deseq, y = bulk_tpm) + 
-    geom_bin_2d(bins = 12) + # signal mostly starts to wash out after this
+    geom_bin_2d(bins = nbins) + 
     geom_smooth(method = "lm", alpha = 0.8, linewidth = 0.5) +
     geom_abline(alpha = 0.8, linewidth = 0.5, color = "red") + 
     facet_wrap(vars(sample_id), nrow = facet_rows) +
@@ -176,7 +176,7 @@ make_binned_scatterplots <- function(df, project_id, facet_rows) {
     
   p2 <- ggplot(df) + 
     aes(x = pseudobulk_log_counts, y = bulk_tpm) + 
-    geom_bin_2d(bins = 12) +
+    geom_bin_2d(bins = nbins) + 
     geom_smooth(method = "lm", alpha = 0.8, linewidth = 0.5) +
     geom_abline(alpha = 0.8, linewidth = 0.5, color = "red") + 
     facet_wrap(vars(sample_id), nrow = facet_rows) +
@@ -189,29 +189,32 @@ make_binned_scatterplots <- function(df, project_id, facet_rows) {
 ```
 
 
-```{r fig.height = 8, fig.width = 12, message=FALSE, warning=FALSE}
+```{r fig.height = 12, fig.width = 12, message=FALSE, warning=FALSE}
 make_binned_scatterplots(
   project_wide_df_list$SCPCP000001, 
   project_id = "SCPCP000001",
+  nbins = 40,
   facet_rows = 6
 )
 ```
 
 
 
-```{r fig.height = 8, fig.width = 12, message=FALSE, warning=FALSE}
+```{r fig.height = 10, fig.width = 12, message=FALSE, warning=FALSE}
 make_binned_scatterplots(
   project_wide_df_list$SCPCP000002, 
   project_id = "SCPCP000002",
+  nbins = 30,
   facet_rows = 6
 )
 ```
 
 
-```{r fig.height = 8, fig.width = 12, message=FALSE, warning=FALSE}
+```{r fig.height = 12, fig.width = 12, message=FALSE, warning=FALSE}
 make_binned_scatterplots(
   project_wide_df_list$SCPCP000006, 
   project_id = "SCPCP000006",
+  nbins = 50,
   facet_rows = 9
 )
 ```
@@ -221,6 +224,7 @@ make_binned_scatterplots(
 make_binned_scatterplots(
   project_wide_df_list$SCPCP000009, 
   project_id = "SCPCP000009",
+  nbins = 15,
   facet_rows = 1
 )
 ```
@@ -230,15 +234,16 @@ make_binned_scatterplots(
 make_binned_scatterplots(
   project_wide_df_list$SCPCP000017, 
   project_id = "SCPCP000017",
+  nbins = 40,
   facet_rows = 7
 )
 ```
 
+We see high concentrations of points around `(0,0`) as well as towards the middle values across plots.
+Next, we'll look at regression stats for these plots directly.
 
-Points are fairly evenly distributed across the scatterplot, except for a very high concentration of points at `0,0` (and into the negatives for `pseudobulk_deseq`). 
 
-
-### Statistics 
+### Statistics: pseudobulk to bulk comparison
 
 Let's now get some stats for the comparison between bulk and pseudobulk.
 We'll fit a linear model for each sample, and display some quantities below both as boxplots and the full table.
@@ -304,8 +309,9 @@ patchwork::wrap_plots(
 ```
 
 * Pseudobulk quantities are exceptionally similar here, which isn't necessarily surprising given the similarity of the pseudobulk measures
-* Relationships are strongest for`SCPCP000001` and `SCPCP000002`, then `SCPCP000006`, and finally `SCPCP000009` and `SCPCP000017`, although `SCPCP00001`, `SCPCP000002`, and `SCPCP000006` do have higher residual sd.
-* Samples within a given project have broadly similar coefficients, with a few outliers, suggesting less of an interaction among samples/expression than one might have thought (although how much do the zeros drive this?)
+* Relationships are strongest for`SCPCP000001` and `SCPCP000002`, then `SCPCP000006`, then `SCPCP000009`, and finally `SCPCP000017` whose relationship is weak if at all present.
+* Samples within a given project have broadly similar coefficients, with a few outliers, suggesting less of an interaction among samples/expression than one might have thought.
+`SCPCP000017` does have more variation here, but also the relationship is very weak in the first place so these different coefficients are not necessarily statistically significantly different.
 
 All the actual values are here:
 
@@ -362,8 +368,7 @@ project_wide_df_list |>
 
 ### Single-cell when bulk TPM is zero
 
-Even though we don't have 1:1 correspondance between pseudobulks here, we'll just consider only points where neither is 0 to get a sense.
-This isn't final.
+
 
 ```{r fig.height=12, fig.width=12, message=FALSE, warning=FALSE}
 project_wide_df_list |>
@@ -371,6 +376,8 @@ project_wide_df_list |>
     \(df, project_id) {
       
       low_bulk <- df |>
+        # Even though we don't have 1:1 correspondence between pseudobulks here,
+        #  we'll just consider only points where neither is 0 to get a sense.
         dplyr::filter(bulk_tpm <= 1e-12, 
                       pseudobulk_deseq> 1e-12, 
                       pseudobulk_log_counts> 1e-12) |>
@@ -399,7 +406,7 @@ A more careful investigation here look into what exactly these genes are, and wh
 
 ### Do pseudobulks have strong disagreements?
 
-This will show genes strongly affected by different normalizations.
+This will show genes strongly affected by different preparation/normalization approaches.
 
 
 ```{r fig.height=12, fig.width=12, message=FALSE, warning=FALSE}

--- a/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
+++ b/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
@@ -10,7 +10,8 @@ output:
 ---
 
 The goal of this notebook is to compare pseudobulk and bulk calculations to determine which pseudobulk calculation should we proceed with for modeling: the log2 of the sum of raw counts (`pseudobulk_log_counts`) or the `DESeq2`-normalized sum of raw counts (`pseudobulk_deseq`).
-To this end, we'll explore pseudobulk expression distributions, compare them to bulk, and also explore distributions of expression where there is disagreement between bulk and single-cell.
+To this end, we'll explore pseudobulk expression distributions, compare them to bulk, and also explore distributions of expression where there is disagreement between bulk and single-cell. 
+We also compare to bulk counts to see which quantity more closely approximates those values.
 
 
 ## Setup
@@ -28,7 +29,7 @@ theme_set(theme_bw())
 data_dir <- here::here("analysis", "pseudobulk-bulk-prediction", "data")
 tpm_dir <- file.path(data_dir, "tpm")
 pseudobulk_dir <- file.path(data_dir, "pseudobulk")
-
+bulk_counts_file <- file.path(data_dir, "scpca_data", "normalized_bulk_counts.rds")
 
 tpm_files <- list.files(
   path = tpm_dir,
@@ -83,6 +84,46 @@ project_wide_df_list <- project_long_df_list |>
 )
 ```
 
+We'll read in the bulk counts data as well which have been normalized with DESeq2.
+
+```{r}
+# we only want to keep these samples from the bulk counts
+present_samples <- project_wide_df_list |>
+  purrr::map(
+    \(df) {
+      df |> 
+        dplyr::pull(sample_id) |> 
+        unique()
+    }
+  ) |>
+  purrr::reduce(c)
+
+# Make a list of data frames of bulk counts, normalized by DESeq2
+bulk_counts_wide_df_list <- readr::read_rds(bulk_counts_file) |>
+  purrr::map(
+    \(df) {
+      df |>
+        dplyr::filter(sample_id %in% present_samples) |>
+        dplyr::rename(ensembl_id = gene_id)
+    }
+  )
+```
+
+
+Bind it up for later comparisons:
+
+```{r}
+project_wide_df_list <- purrr::map2(
+  bulk_counts_wide_df_list, 
+  project_wide_df_list, 
+  \(df_counts, df_main) {
+    
+    df_main |>
+      dplyr::left_join(df_counts, by = c("ensembl_id", "sample_id"))
+  }
+)
+```
+
 
 ## Full distributions
 
@@ -110,18 +151,17 @@ All around, distributions range from their lower bound up to around 20, so it's 
 
 This section will look at the relationship among quantities.
 
-  
-### Scatterplots 
-
-First, we'll look at some scatterplots:
+In this section, we'll look at some scatterplots:
 
 * How similar are the pseudobulk measures themselves?
-* How does each pseudobulk measure compare to bulk?
+* How does each pseudobulk measure compare to bulk TPM?
   * For these plots, we'll bin data to see the concentration of overlapping points more easily.
-
+* How does each pseudobulk measure compare to bulk normalized counts (not TPM)?
+  * For these plots, we'll bin data to see the concentration of overlapping points more easily.
 In all plots, the red line is `y=x`, and the blue line is the regression line.
 
-#### Compare pseudobulk measures
+
+### Compare pseudobulk measures
 
 ```{r fig.height=34, fig.width=8, message=FALSE, warning=FALSE}
 project_wide_df_list |>
@@ -148,28 +188,29 @@ These quantities are exceptionally similar with these differences:
 * In a handful of samples (1-2 per project), `pseudobulk_log_counts` appears to have a higher proportion of low to zero counts, and throughout has lower values than `pseudobulk_deseq`.
 
 
-#### Compare pseudobulk to bulk
+### Compare pseudobulk to bulk counts
 
-To make sure we get a good view, we'll first make the plots and then show them per project with their plot settings.
+We'd like to also get a sense of how this data compares to counts directly.
+
 
 ```{r}
 # Helper function to visualize scatterplots with geom_bin_2d()
-make_binned_scatterplots <- function(df, project_id, nbins, facet_rows) {
+make_binned_scatterplots <- function(df, project_id, yvar, nbins, facet_rows) {
   p1 <- ggplot(df) + 
-    aes(x = pseudobulk_deseq, y = bulk_tpm) + 
+    aes(x = pseudobulk_deseq, y = {{yvar}}) + 
     geom_bin_2d(bins = nbins) + 
     geom_smooth(method = "lm", alpha = 0.8, linewidth = 0.5) +
     geom_abline(alpha = 0.8, linewidth = 0.5, color = "red") + 
     facet_wrap(vars(sample_id), nrow = facet_rows) +
-    ggtitle("bulk_tpm ~ deseq") 
+    ggtitle("~ deseq") 
     
   p2 <- ggplot(df) + 
-    aes(x = pseudobulk_log_counts, y = bulk_tpm) + 
+    aes(x = pseudobulk_log_counts, y = {{yvar}}) + 
     geom_bin_2d(bins = nbins) + 
     geom_smooth(method = "lm", alpha = 0.8, linewidth = 0.5) +
     geom_abline(alpha = 0.8, linewidth = 0.5, color = "red") + 
     facet_wrap(vars(sample_id), nrow = facet_rows) +
-    ggtitle("bulk_tpm ~ log_counts") 
+    ggtitle("~ log_counts") 
       
   print(
     patchwork::wrap_plots(p1, p2, ncol = 2) + patchwork::plot_annotation(title = project_id)
@@ -178,10 +219,156 @@ make_binned_scatterplots <- function(df, project_id, nbins, facet_rows) {
 ```
 
 
+
+
 ```{r fig.height = 12, fig.width = 12, message=FALSE, warning=FALSE}
 make_binned_scatterplots(
   project_wide_df_list$SCPCP000001, 
   project_id = "SCPCP000001",
+  yvar = bulk_counts,
+  nbins = 15,
+  facet_rows = 6
+)
+```
+
+
+
+```{r fig.height = 10, fig.width = 12, message=FALSE, warning=FALSE}
+make_binned_scatterplots(
+  project_wide_df_list$SCPCP000002, 
+  project_id = "SCPCP000002",
+  yvar = bulk_counts,
+  nbins = 15,
+  facet_rows = 6
+)
+```
+
+
+```{r fig.height = 12, fig.width = 12, message=FALSE, warning=FALSE}
+make_binned_scatterplots(
+  project_wide_df_list$SCPCP000006, 
+  project_id = "SCPCP000006",
+  yvar = bulk_counts,
+  nbins = 15,
+  facet_rows = 9
+)
+```
+
+
+```{r fig.height = 3, fig.width = 12, message=FALSE, warning=FALSE}
+make_binned_scatterplots(
+  project_wide_df_list$SCPCP000009, 
+  project_id = "SCPCP000009",
+  yvar = bulk_counts,
+  nbins = 15,
+  facet_rows = 1
+)
+```
+
+
+```{r fig.height = 8, fig.width = 12, message=FALSE, warning=FALSE}
+make_binned_scatterplots(
+  project_wide_df_list$SCPCP000017, 
+  project_id = "SCPCP000017",
+  yvar = bulk_counts,
+  nbins = 40,
+  facet_rows = 7
+)
+```
+
+
+
+
+#### Statistics
+
+Let's now get some stats for the comparison between bulk counts and pseudobulk.
+We'll fit a linear model for each sample, and display some quantities below both as boxplots and the full table.
+
+```{r fig.height = 10, fig.width = 12}
+# Helper functions to plot model statistics from data frame
+plot_stats <- function(df, column, title) {
+  ggplot(df) + 
+    aes(x = expression_type, y = {{column}}, color = expression_type) + 
+    geom_boxplot() + 
+    scale_color_brewer(palette = "Dark2") +
+    ggtitle(title) +
+    facet_wrap(vars(project_id), nrow = 1) +
+    theme(legend.position = "none")
+}
+
+model_samples_counts <- function(id, df) {
+  sample_df <- df |>
+    dplyr::filter(sample_id == id) 
+  
+  df_deseq <- sample_df |>
+    dplyr::filter(is.finite(pseudobulk_deseq), is.finite(bulk_counts))
+  fit_deseq <- summary(lm(bulk_counts ~ pseudobulk_deseq, data = df_deseq))
+
+  df_log_counts <- sample_df |>
+      dplyr::filter(is.finite(pseudobulk_log_counts), is.finite(bulk_counts))
+  fit_log_counts <- summary(lm(bulk_counts ~ pseudobulk_log_counts, data = df_log_counts))
+      
+  # Tabulate and return some fit stats
+  data.frame(
+    expression_type = c("deseq", "log_counts"),
+    rsquared = c(fit_deseq$r.squared, fit_log_counts$r.squared), 
+    coeff = c(fit_deseq$coefficients[2], fit_log_counts$coefficients[2]), 
+    residual_sd = c(fit_deseq$sigma,  fit_log_counts$sigma)
+  )
+}
+
+stats_df <- project_wide_df_list |>
+  purrr::map(
+    \(df) {
+      
+      # We need to map over sample ids now
+      samples <- unique(df$sample_id)
+      names(samples) <- samples
+      
+      fit_table <- samples |>
+        purrr::map(model_samples_counts, df) |>
+        purrr::list_rbind(names_to = "sample_id")
+      
+      return(fit_table)
+
+    }
+  ) |>
+  # now, combine all projects into a single table
+  purrr::list_rbind(names_to = "project_id")
+
+patchwork::wrap_plots(
+  plot_stats(stats_df, rsquared, "rsquared"),
+  plot_stats(stats_df, coeff, "coeff"), 
+  plot_stats(stats_df, residual_sd, "residual_sd"), 
+  nrow = 3
+) 
+```
+
+* Relationships between pseudobulk and bulk counts are exceptionally similar here, and further we are generally lying along the 1:1 line.
+* `SCPCP000001` and `SCPCP000002` have some outlying samples where `log_counts` performs worse, which are likely the cases we see in the scatterplots where the relationship with `log_counts` shows bias relative to `y=x`
+* Relationships are strongest for`SCPCP000001` and `SCPCP000002`, then `SCPCP000006`, then `SCPCP000009`, and finally `SCPCP000017` whose relationship is weak if at all present.
+* Samples within a given project have broadly similar coefficients, with a few outliers, suggesting less of an interaction among samples/expression than one might have thought.
+`SCPCP000017` does have more variation here, but also the relationship is very weak in the first place so these different coefficients are not necessarily statistically significantly different.
+
+All the actual values are here:
+
+
+```{r}
+stats_df
+```
+
+
+
+### Compare pseudobulk to bulk TPM
+
+
+Now we'll do the same for pseudobulk and bulk TPM
+
+```{r fig.height = 12, fig.width = 12, message=FALSE, warning=FALSE}
+make_binned_scatterplots(
+  project_wide_df_list$SCPCP000001, 
+  project_id = "SCPCP000001",
+  yvar = bulk_tpm,
   nbins = 40,
   facet_rows = 6
 )
@@ -193,6 +380,7 @@ make_binned_scatterplots(
 make_binned_scatterplots(
   project_wide_df_list$SCPCP000002, 
   project_id = "SCPCP000002",
+  yvar = bulk_tpm,
   nbins = 30,
   facet_rows = 6
 )
@@ -203,6 +391,7 @@ make_binned_scatterplots(
 make_binned_scatterplots(
   project_wide_df_list$SCPCP000006, 
   project_id = "SCPCP000006",
+  yvar = bulk_tpm,
   nbins = 50,
   facet_rows = 9
 )
@@ -213,6 +402,7 @@ make_binned_scatterplots(
 make_binned_scatterplots(
   project_wide_df_list$SCPCP000009, 
   project_id = "SCPCP000009",
+  yvar = bulk_tpm,
   nbins = 15,
   facet_rows = 1
 )
@@ -223,6 +413,7 @@ make_binned_scatterplots(
 make_binned_scatterplots(
   project_wide_df_list$SCPCP000017, 
   project_id = "SCPCP000017",
+  yvar = bulk_tpm,
   nbins = 40,
   facet_rows = 7
 )
@@ -232,24 +423,14 @@ We see high concentrations of points around `(0,0`) as well as towards the middl
 Next, we'll look at regression stats for these plots directly.
 
 
-### Statistics: pseudobulk to bulk comparison
+#### Statistics
 
-Let's now get some stats for the comparison between bulk and pseudobulk.
+Let's now get some stats for the comparison between bulk TPM and pseudobulk.
 We'll fit a linear model for each sample, and display some quantities below both as boxplots and the full table.
 
 ```{r fig.height = 10, fig.width = 12}
-# Helper function to plot model statistics from data frame
-plot_stats <- function(df, column, title) {
-  ggplot(df) + 
-    aes(x = expression_type, y = {{column}}, color = expression_type) + 
-    geom_boxplot() + 
-    scale_color_brewer(palette = "Dark2") +
-    ggtitle(title) +
-    facet_wrap(vars(project_id), nrow = 1) +
-    theme(legend.position = "none")
-}
 
-model_samples <- function(id, df) {
+model_samples_tpm <- function(id, df) {
   sample_df <- df |>
     dplyr::filter(sample_id == id) 
   
@@ -279,7 +460,7 @@ stats_df <- project_wide_df_list |>
       names(samples) <- samples
       
       fit_table <- samples |>
-        purrr::map(model_samples, df) |>
+        purrr::map(model_samples_tpm, df) |>
         purrr::list_rbind(names_to = "sample_id")
       
       return(fit_table)
@@ -311,6 +492,8 @@ stats_df
 
 
 ## Disagreeing expression
+
+Currently this section does not include bulk counts, only bulk TPM.
 
 Next, we'll take a quick look at cases where one modality has zero expression and the other doesn't.
 In these cases, if expression is generally high, we have evidence of disagreement/discrepancy between bulk and single-cell that may be interesting to investigate.

--- a/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
+++ b/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
@@ -9,9 +9,8 @@ output:
     code_folding: show
 ---
 
-The goal of this notebook is to compare pseudobulk and bulk calculations to determine which pseudobulk calculation should we proceed with for modeling: the sum of logcounts (`pseudobulk_logcounts`) or the `DESeq2`-normalized sum of raw counts (`pseudobulk_deseq`).
+The goal of this notebook is to compare pseudobulk and bulk calculations to determine which pseudobulk calculation should we proceed with for modeling: the log2 of the sum of raw counts (`pseudobulk_log_counts`) or the `DESeq2`-normalized sum of raw counts (`pseudobulk_deseq`).
 To this end, we'll visualize expression distributions, both on their own and compared to bulk TPM. 
-
 
 
 ## Setup
@@ -56,7 +55,8 @@ stopifnot(
 
 ### Read and prepare input data
 
-We'll make both a long and wide version of the data for each project.
+We'll make both a long and wide version of the data for convenience throughout the notebook.
+
 
 ```{r}
 project_long_df_list <- purrr::map2(
@@ -65,7 +65,9 @@ project_long_df_list <- purrr::map2(
   \(tpm_file, pseudo_file) {
     
     dplyr::bind_rows(
-      readr::read_tsv(tpm_file, show_col_types = FALSE),
+      # TPM needs to be in log2 space
+      readr::read_tsv(tpm_file, show_col_types = FALSE) |>
+        dplyr::mutate(expression = log2(expression)),
       readr::read_tsv(pseudo_file, show_col_types = FALSE)
     )
   }
@@ -82,152 +84,214 @@ project_wide_df_list <- project_long_df_list |>
 ```
 
 
-## Bulk TPM distributions
-
-When establishing pseudobulk datasets, genes with low expression levels were removed. 
-
-Before looking at pseudobulk measures here, we'll look at how the TPM distributions (log2) compared between for genes that are and are not included in the pseudobulk datasets. the comparisons.
-We expect to see that genes not included in the pseudobulk have lower TPM.
-
-
-```{r, fig.width = 12,  fig.height = 4, warning=FALSE}
-tpm_df_indicator_list |>
-  purrr::imap(
-    \(df, project_id) {
-      
-      ggplot(df) + 
-        aes(x = log2(expression), fill = in_pseudo) + 
-        geom_density(alpha = 0.5) + 
-        labs(
-          title = project_id, 
-          x = "log2 bulk TPM"
-        ) +
-        theme(legend.position = "bottom")
-    }
-  ) |>
-  patchwork::wrap_plots(guides = "collect", nrow = 1) & theme(legend.position = "bottom")
-
-
-```
-
-We mostly see the expected trend: Genes included in the pseudobulk counts have higher expression in bulk compared to genes which were removed.
-`SCPCP000009` is an exception here, but this project has fewer samples compared to the rest so this could be a power artifact:
-
-```{r}
-tpm_df_indicator_list |>
-  purrr::map(
-    \(df) length(unique(df$sample_id))
-  )
-```
-
-Pause to clean up a little!
-
-```{r}
-rm(tpm_df_indicator_list)
-```
-
-
-## Distributions of pseudobulk
+## Distributions of expression values
 
 
 First, let's get a general sense of the scale of values in the pseudobulk quantities:
 
-
 ```{r}
-## logcounts
-project_df_list |>
+project_wide_df_list |>
   purrr::map(
     \(df) {
-      df |> 
-        dplyr::filter(expression_type == "pseudobulk_logcounts") |>
-        dplyr::pull(expression) |> 
+      df |>
+        # consider only genes with values not lost to transformation
+        dplyr::filter(is.finite(pseudobulk_log_counts)) |>
+        dplyr::pull(pseudobulk_log_counts) |>
         summary()
-  })
-```
-
-
-```{r}
-## deseq
-project_df_list |>
-  purrr::map(
-    \(df) {
-      df |> 
-        dplyr::filter(expression_type == "pseudobulk_deseq") |>
-        dplyr::pull(expression) |> 
-        summary()
-  })
-```
-
-The logcounts version has some strong right-skew, so we should log those values to support modeling. 
-We don't see the same level of skew from DESeq, which is good since we don't expect to see it out of that normalization procedure; we don't need to transform those.
-
-Let's therefore update expression to be log2 for both TPM and pseudobulk logcounts (i.e., for all but pseudobulk deseq) since we'll use those scales moving forward:
-
-```{r warning = FALSE}
-project_df_list <- project_df_list |>
-  purrr::map(
-    \(df) {
-        df |>
-          dplyr::mutate(expression = ifelse(
-            stringr::str_detect(expression_type, "deseq"),
-            expression,
-            log2(expression) # TODO: do we want a fudge here?
-          ))
     }
   )
 ```
 
-Now, we can visualize distributions of all quantities:
 
-```{r, fig.width = 12, fig.height = 8}
-project_df_list |>
+```{r}
+project_wide_df_list |>
+  purrr::map(
+    \(df) summary(df$pseudobulk_deseq)
+  )
+```
+
+
+
+Due to the different transformation approaches, the `pseudobulk_deseq` version has some negatives for fractional values, but `pseudobulk_log_counts` has a lower bound of 0.
+These different scales of data are important to keep in mind.
+
+
+### Undefined values
+
+Due to the `log2` transformation and sparsity of scRNA-seq counts, many values in `pseudobulk_log_counts` are expected to be `-Inf`, aka essentially unobserved in the single-cell data.
+We'll look at histograms, per project, of the percentage of genes with _defined_:
+
+```{r fig.height = 3, fig.width = 8}
+finite_df <- project_wide_df_list |>
+  purrr::map(
+    \(df) {
+      df |>
+        dplyr::count(sample_id, is_finite = is.finite(pseudobulk_log_counts)) |>
+        tidyr::pivot_wider(
+          names_from = is_finite, 
+          values_from = n, 
+          names_prefix = "finite_",
+          values_fill = 0
+        ) |>
+        dplyr::mutate(percent_genes_with_expression = finite_TRUE/(finite_FALSE + finite_TRUE))
+    }) |>
+  purrr::list_rbind(names_to = "project_id")
+
+
+ggplot(finite_df) +
+  aes(x = percent_genes_with_expression, fill = project_id) + 
+  geom_histogram(bins = 15) + 
+  facet_wrap(vars(project_id), nrow = 1) + 
+  theme(legend.position = "none")
+```
+It looks like about half the genes, but ranging from ~20 - 60\%, of genes in a given sample are non-zero.
+This means about 40-80\% of genes in the genome are not observed per sample.
+
+
+What are the `pseudobulk_deseq` values where the `pseudobulk_log_counts` values (above) are `-Inf`?
+
+```{r fig.height = 3, fig.width = 8}
+deseq_inf_df <- project_wide_df_list |>
+  purrr::map(
+    \(df) dplyr::filter(df, is.infinite(pseudobulk_log_counts))
+  )|>
+  purrr::list_rbind(names_to = "project_id")
+
+
+ggplot(deseq_inf_df) +
+  aes(x = pseudobulk_deseq, fill = project_id) + 
+  geom_histogram(bins = 15) + 
+  facet_wrap(vars(project_id), nrow = 1) + 
+  theme(legend.position = "none")
+```
+
+So, lots of the 0s are here which we expect to see.
+Are _all_ the 0s here?
+
+If all the 0s are the same as all the infinites, then there should be no rows where 0 and finite co-occur:
+
+
+```{r}
+project_wide_df_list |>
+  purrr::map(
+    \(df) {
+      df |>
+        # when deseq is 0, is log_counts always -inf?
+        dplyr::filter(
+          pseudobulk_deseq == 0, 
+          is.finite(pseudobulk_log_counts)
+        ) |>
+        nrow()
+  })
+```
+Indeed, `pseudobulk_log_counts` is never finite (aka, it is always `-Inf`) when `pseudobulk_deseq` is 0, which is good to know.
+
+
+Let's also check if we have the same genes between bulk and single-cell.
+Any genes present in one modality but not the other will have `NA` expression (transforming any 0 expressions will have produced `-Inf`, not `NA`, so those `NA`s are from joining).
+
+Are any in single-cell but not bulk?
+```{r}
+project_wide_df_list |>
+  purrr::map(\(df){
+    df |> 
+      dplyr::filter(!is.na(bulk_tpm), 
+                    is.na(pseudobulk_deseq), 
+                    is.na(pseudobulk_log_counts)) 
+  }) |>
+  dplyr::bind_rows()
+
+```
+Nope! How about single-cell but not bulk?
+```{r}
+only_single_cell <- project_wide_df_list |>
+  purrr::map(\(df){
+    df |> 
+      dplyr::filter(is.na(bulk_tpm), 
+                    !is.na(pseudobulk_deseq), 
+                    !is.na(pseudobulk_log_counts)) 
+  }) |>
+  purrr::list_rbind(names_to = "project_id") |>
+  dplyr::count(project_id, ensembl_id)
+only_single_cell
+```
+
+
+Yup!
+Plus, these numbers are all the sample numbers...
+
+```{r}
+only_single_cell |>
+  dplyr::count(ensembl_id)
+```
+..and it's the same genes all round (probably a reference thing...?).
+
+
+In any case, what is the expression of these genes in pseudobulk?
+```{r fig.height=3, fig.width=8}
+genes_not_in_bulk <- project_wide_df_list |>
+  purrr::map(
+  \(df) df |> dplyr::filter(is.na(bulk_tpm)) 
+) |>
+  purrr::list_rbind(names_to = "project_id") |>
+  dplyr::select(-bulk_tpm) |>
+  tidyr::pivot_longer(
+    contains("pseudobulk"), 
+    names_to = "expression_type", 
+    values_to = "expression"
+  )
+
+ggplot(genes_not_in_bulk) + 
+  aes(x = expression_type, y = expression) +
+  geom_boxplot() + 
+  facet_wrap(vars(project_id), nrow = 1) +
+  theme(axis.text.x = element_text(angle = 30, hjust = 1))
+```
+Some of these genes actually have decent values in single-cell.
+
+
+### Full distributions
+
+Here, we visualize distributions of all quantities:
+
+```{r, fig.width = 12, fig.height = 8, warning = FALSE}
+project_long_df_list |>
   purrr::imap(
     \(df, project_id) {
-      
-     ggplot(df) + 
-        aes(x = expression, fill = expression_type) + 
-        geom_density(alpha = 0.5) + 
-        scale_fill_brewer(palette = "Dark2") + 
-        facet_wrap(vars(expression_type), scales = "free", nrow = 3) +
-        ggtitle(project_id) +
-        theme(legend.position = "none")
+       ggplot(df) + 
+          aes(x = expression, fill = expression_type) + 
+          geom_density(alpha = 0.5) + 
+          scale_fill_brewer(palette = "Dark2") + 
+          facet_wrap(vars(expression_type), scales = "free", nrow = 4) +
+          ggtitle(project_id) +
+          theme(legend.position = "none")
     }
   ) |>
   patchwork::wrap_plots(guides = "collect", nrow = 1)
 ```
 
-Both the pseudobulk distributions look reasonable enough!
 
 
 ## Relationship between quantities
 
-Now come the many plots: What does the relationship look like between bulk and each flavor of pseudobulk?
-We'll visualize this per sample.
 
-We'll first make a pivoted version of this data to enable plotting and modeling.
+This section will look at the relationship between bulk and pseudobulk quantities with:
 
+* scatterplots to confirm if we have a linear relationship
+* per-sample linear models of `bulk ~ pseudobulk` to do a cursory comparison of model statistics
+  * these results are presented both as plots and as the full per-sample table to scroll through
+  
+  
+### Scatterplots 
 
-```{r}
-project_df_wide_list <- project_df_list |>
-  purrr::imap(
-    \(df, project_id) {
-       df |> 
-        tidyr::pivot_wider(
-          names_from = expression_type, 
-          values_from = expression
-        )
-    })
-```
-
-
-Next, we have many plots, organized by project:
+What does the relationship look like between bulk and each flavor of pseudobulk?
+Plots are organized by project and:
 
 * Left-side panels are `bulk tpm ~ deseq pseudocounts`
-* Center panels are `bulk tpm ~ logcounts pseudocounts`
-* Right-side panels are `deseq pseudocounts ~ logcounts pseudocounts`, to assess their similarity directly
+* Right-side panels are `bulk tpm ~ log_counts pseudocounts`
 
-```{r fig.height=30, fig.width=18, message=FALSE, warning=FALSE}
-project_df_wide_list |>
+```{r fig.height=35, fig.width=18, message=FALSE, warning=FALSE}
+project_wide_df_list |>
   purrr::imap(
     \(df, project_id) {
       
@@ -239,102 +303,102 @@ project_df_wide_list |>
         ggtitle("bulk tpm ~ deseq")
       
       p2 <- ggplot(df) + 
-        aes(x = pseudobulk_logcounts, y = bulk_tpm) + 
+        aes(x = pseudobulk_log_counts, y = bulk_tpm) + 
         geom_point(alpha = 0.2, size = 0.5) + 
         geom_smooth(method = "lm") +
         facet_wrap(vars(sample_id), nrow = 5) +
         ggtitle("bulk tpm ~ logcounts") 
-      
-       p3 <- ggplot(df) + 
-        aes(x = pseudobulk_logcounts, y = pseudobulk_deseq) + 
-        geom_point(alpha = 0.2, size = 0.5) + 
-        geom_smooth(method = "lm") +
-        facet_wrap(vars(sample_id), nrow = 5) +
-        ggtitle("deseq ~ logcounts") 
            
       
-      patchwork::wrap_plots(p1, p2, p3) 
+      patchwork::wrap_plots(p1, p2) 
 
     }
   ) |>
   patchwork::wrap_plots(nrow = 5)
 ```
 
-On the whole, the relationship between bulk and pseudobulk look exceptionally similar regardless of which pseudobulk quantity is used!
-On the right-side, we see that indeed the pseudobulk versions are highly similar to one another (right-side panels).
-The main difference we can pick out from these plots is that the `logcounts` version has a band of lowly-expressed genes which the `deseq` version doesn't appear to show, which again is consistent with their different origins.
 
+### Statistics 
 
-To identify if there's a meaningful benefit to using one pseudobulk version over another, we'll build linear models of `tpm ~ pseudobulk * sample`; we can assume an interaction based on the slopes in the above scatterplots.
-Note that these are not final models for analysis, but only used to guide our next steps of actually building/fine-tuning the models.
+Let's now get some stats for each sample.
+We'll fit a linear model for each sample, and display some quantities below both as boxplots and the full table.
 
-We'll also have a look at the distributions of model residuals along the way.
+```{r fig.height = 10, fig.width = 12}
 
-```{r fig.height = 2, fig.width = 5}
-project_df_wide_list |>
+plot_stats <- function(df, column, title) {
+  ggplot(df) + 
+    aes(x = expression_type, y = {{column}}, color = expression_type) + 
+    geom_boxplot() + 
+    scale_color_brewer(palette = "Dark2") +
+    ggtitle(title) +
+    facet_wrap(vars(project_id), nrow = 1) +
+    theme(legend.position = "none")
+}
+
+model_samples <- function(id, df) {
+  sample_df <- df |>
+    dplyr::filter(sample_id == id) 
+  
+  df_deseq <- sample_df |>
+    dplyr::filter(is.finite(pseudobulk_deseq), is.finite(bulk_tpm))
+  fit_deseq <- lm(bulk_tpm ~ pseudobulk_deseq, data = df_deseq) 
+
+  df_log_counts <- sample_df |>
+      dplyr::filter(is.finite(pseudobulk_log_counts), is.finite(bulk_tpm))
+  fit_log_counts <- lm(bulk_tpm ~ pseudobulk_log_counts, data = df_log_counts)
+      
+  # Tabulate and return some fit stats
+  data.frame(
+    expression_type = c("deseq", "log_counts"),
+    rsquared = c(broom::glance(fit_deseq)$r.squared, broom::glance(fit_log_counts)$r.squared), 
+    coeff = c(broom::tidy(fit_deseq)$estimate[2], broom::tidy(fit_log_counts)$estimate[2]), 
+    residual_sd = c(broom::glance(fit_deseq)$sigma, broom::glance(fit_log_counts)$sigma)
+  )
+}
+
+stats_df <- project_wide_df_list |>
   purrr::map(
     \(df) {
       
-      # Build models
-      # We first need to remove any undefined values for each model
-      df_deseq <- df |>
-        dplyr::filter(is.finite(pseudobulk_deseq), is.finite(bulk_tpm))
-      fit_deseq <- lm(bulk_tpm ~ pseudobulk_deseq * sample_id, data = df_deseq)
-    
-      df_logcounts <- df |>
-        dplyr::filter(is.finite(pseudobulk_logcounts), is.finite(bulk_tpm))
-      fit_logcounts <- lm(bulk_tpm ~ pseudobulk_logcounts * sample_id, data = df_logcounts)
+      # We need to map over sample ids now
+      samples <- unique(df$sample_id)
+      names(samples) <- samples
       
-      # Tabulate some fit stats
-      fit_table <- tibble::tribble(
-        ~expression_type, ~rsquared, ~residual_sd, 
-        "deseq", broom::glance(fit_deseq)$r.squared, broom::glance(fit_deseq)$sigma, 
-        "logcounts", broom::glance(fit_logcounts)$r.squared, broom::glance(fit_logcounts)$sigma
-      )
+      fit_table <- samples |>
+        purrr::map(model_samples, df) |>
+        purrr::list_rbind(names_to = "sample_id")
       
-      
-      # Tabulate some fit stats, wide for easier viewing
-      broom_deseq <- broom::glance(fit_deseq)
-      broom_logcounts <- broom::glance(fit_logcounts)
-      fit_table <- data.frame(
-        deseq_rsquared        = broom_deseq$r.squared,
-        logcounts_rsquared    = broom_logcounts$r.squared,
-        deseq_residual_sd     = broom_deseq$sigma,
-        logcounts_residual_sd = broom_logcounts$sigma    
-      )
-      
-      # Plot the residuals as well on the way down
-      deseq_augment <- broom::augment(fit_deseq)
-      logcounts_augment <- broom::augment(fit_logcounts)
-      
-      p1 <- ggplot(deseq_augment) + 
-        aes(x = pseudobulk_deseq, y = .resid) + 
-        geom_point(size = 0.5, alpha = 0.5) + 
-        geom_hline(yintercept = 0, color = "red") +
-        ggtitle("deseq")
-      p2 <- ggplot(logcounts_augment) + 
-        aes(x = pseudobulk_logcounts, y = .resid) + 
-        geom_point(size = 0.5, alpha = 0.5) + 
-        geom_hline(yintercept = 0, color = "red") +
-        ggtitle("logcounts")
-      
-      print(patchwork::wrap_plots(p1, p2, nrow = 1))
-      
-      # actually return the fit info
-      fit_table
-      
+      return(fit_table)
+
     }
-) |>
+  ) |>
+  # now, combine all projects into a single table
   purrr::list_rbind(names_to = "project_id")
+
+patchwork::wrap_plots(
+  plot_stats(stats_df, rsquared, "rsquared"),
+  plot_stats(stats_df, coeff, "coeff"), 
+  plot_stats(stats_df, residual_sd, "residual_sd"), 
+  nrow = 3
+) 
+
+
+
 ```
 
-Models from different pseudobulk quantities are expectedly, based on scatterplots above,  minimal, and based on the residual plots around linear model assumptions seem reasonably met.
-The `DESeq2` flavor appears to marginally outperform (based on these limited stats) in 3/5 projects. 
+* Pseudobulk quantities are mostly similar, and `pseudobolk_deseq` tends to outperform `pseudobolk_log_counts` for all projects except `SCPCP000009`, but notably there are only 3 samples for this project
+* Correlations are mostly zero or very low for `SCPCP000017`, and `SCPCP000001` and `SCPCP000002` show the strongest relationships overall
 
-## Conclusions
 
-Either calculation for pseudobulk appears to be fine, and it's likely that we'd get roughly the same results either way.
-I would suggest to proceed with the `DESeq2` normalized version since we do not need additional `log2` transformations, which leads to loss of 0-expression genes in the model since they are undefined (unless we want to fudge factor them, but avoiding this if we can seems best).
+All the actual values are here:
+
+
+```{r}
+stats_df
+```
+
+
+
 
 ## Session info
 

--- a/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
+++ b/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
@@ -9,9 +9,18 @@ output:
     code_folding: hide
 ---
 
-The goal of this notebook is to compare pseudobulk and bulk calculations to determine which pseudobulk calculation should we proceed with for modeling: the log2 of the sum of raw counts (`pseudobulk_log_counts`) or the `DESeq2`-normalized sum of raw counts (`pseudobulk_deseq`).
-To this end, we'll explore pseudobulk expression distributions, compare them to bulk, and also explore distributions of expression where there is disagreement between bulk and single-cell. 
-We also compare to bulk counts to see which quantity more closely approximates those values.
+The goal of this notebook is to compare pseudobulk and bulk calculations to determine which calculation flavors we should proceed with.
+We compare two pseudobulk and two bulk measures:
+
+* Pseudobulk:
+  * `pseudobulk_deseq`: raw counts summed and normalized with `DESeq2`
+  * `pseudobulk_log_counts`: raw counts summed and with a `log2(x+1)` transformation
+* Bulk:
+  * `bulk_counts`: Bulk raw counts normalized with `DESeq2`
+  * `bulk_tpm`: TPM bulk data on a `log2` scale
+  
+  
+We'll explore expression distributions, the relationships between bulk and pseudobulk measures, and we'll also have a brief look at  whether there are any genes with strong disagreement between bulk and single-cell. 
 
 
 ## Setup
@@ -60,35 +69,34 @@ We'll make both a long and wide version of the data for convenience throughout t
 
 
 ```{r}
-project_long_df_list <- purrr::map2(
+project_df_list <- purrr::map2(
   tpm_files, 
   pseudobulk_files, 
   \(tpm_file, pseudo_file) {
     
+    tpm_df <- readr::read_tsv(tpm_file, show_col_types = FALSE) |>
+      #  TPM needs to be in log2 space
+      dplyr::mutate(expression = log2(expression))
+    
+    pseudo_df <- readr::read_tsv(pseudo_file, show_col_types = FALSE) 
+    
     dplyr::bind_rows(
-      # TPM needs to be in log2 space
-      readr::read_tsv(tpm_file, show_col_types = FALSE) |>
-        dplyr::mutate(expression = log2(expression)), 
-      readr::read_tsv(pseudo_file, show_col_types = FALSE)
-    )
+      tpm_df, 
+      pseudo_df
+    ) |>
+      tidyr::pivot_wider(
+        names_from = expression_type, 
+        values_from = expression
+      )
   }
-)
-
-# Make a wide version as well
-project_wide_df_list <- project_long_df_list |>
-  purrr::map(
-    \(df) {
-      df |>
-        tidyr::pivot_wider(names_from = expression_type, values_from = expression)
-    }
 )
 ```
 
-We'll read in the bulk counts data as well which have been normalized with DESeq2.
+We'll read in the bulk counts data and combine with the rest of the data.
 
 ```{r}
 # we only want to keep these samples from the bulk counts
-present_samples <- project_wide_df_list |>
+present_samples <- project_df_list |>
   purrr::map(
     \(df) {
       df |> 
@@ -99,7 +107,7 @@ present_samples <- project_wide_df_list |>
   purrr::reduce(c)
 
 # Make a list of data frames of bulk counts, normalized by DESeq2
-bulk_counts_wide_df_list <- readr::read_rds(bulk_counts_file) |>
+bulk_df_list <- readr::read_rds(bulk_counts_file) |>
   purrr::map(
     \(df) {
       df |>
@@ -107,34 +115,17 @@ bulk_counts_wide_df_list <- readr::read_rds(bulk_counts_file) |>
         dplyr::rename(ensembl_id = gene_id)
     }
   )
-```
 
-
-Combine `bulk_counts` data with the full data frame lists (not the most efficient but gets it done!):
-
-```{r}
-project_wide_df_list <- purrr::map2(
-  bulk_counts_wide_df_list, 
-  project_wide_df_list, 
+# Combine the data
+project_df_list <- purrr::map2(
+  bulk_df_list, 
+  project_df_list, 
   \(df_counts, df_main) {
     
     df_main |>
       dplyr::left_join(df_counts, by = c("ensembl_id", "sample_id"))
   }
 )
-
-project_long_df_list <- purrr::map2(
-  bulk_counts_wide_df_list, 
-  project_long_df_list, 
-  \(df_counts, df_main) {
-    
-    df_counts |>
-      dplyr::rename(expression = bulk_counts) |>
-      dplyr::mutate(expression_type = "bulk_counts") |>
-      dplyr::bind_rows(df_main)
-    
-  })
-  
 ```
 
 
@@ -143,7 +134,15 @@ project_long_df_list <- purrr::map2(
 First, we'll visualize distributions of all quantities:
 
 ```{r, fig.width = 7, fig.height = 7, warning = FALSE}
-ggplot(purrr::list_rbind(project_long_df_list, names_to = "project_id")) + 
+plot_df <- project_df_list |>
+  purrr::list_rbind(names_to = "project_id") |> 
+  tidyr::pivot_longer(
+    c(-project_id, -ensembl_id, -sample_id), 
+    names_to = "expression_type", 
+    values_to = "expression"
+  )
+
+ggplot(plot_df) + 
   aes(x = expression, fill = expression_type) + 
   geom_density(alpha = 0.5) + 
   scale_fill_brewer(palette = "Dark2") + 
@@ -157,15 +156,19 @@ ggplot(purrr::list_rbind(project_long_df_list, names_to = "project_id")) +
 
 We see big spikes at zero for pseudobulk, not surprisingly.
 Due to the different transformation approaches, the `pseudobulk_deseq` version has some negatives for fractional values, but the other quantities have a lower bound of zero.
-All around, distributions range from their lower bound up to around 20, so it's nice to know pseudobulk and bulk are definitely on the same scale.
+All around, distributions are concetrated range from their lower bound to around 20, so it's nice to know pseudobulk and bulk are definitely on the same scale.
 In the bulk counts, `SCPCP000017` seems to have a much larger peak at zero compared to other projects.
 
   
+Let's clean up for memory here.
+```{r}
+rm(plot_df)
+gc()
+```
+
 ## Relationship between quantities
 
-This section will look at the relationship among quantities.
-
-In this section, we'll look at some scatterplots:
+This section will look at the relationship among quantities:
 
 * How similar are the pseudobulk measures themselves?
 * How does each pseudobulk measure compare to bulk TPM?
@@ -178,7 +181,7 @@ In all plots, the red line is `y=x`, and the blue line is the regression line.
 ### Compare pseudobulk measures
 
 ```{r fig.height=34, fig.width=8, message=FALSE, warning=FALSE}
-project_wide_df_list |>
+project_df_list |>
   purrr::imap(
     \(df, project_id) {
       
@@ -202,11 +205,11 @@ These quantities are exceptionally similar with these differences:
 * In a handful of samples (1-2 per project), `pseudobulk_log_counts` appears to have a higher proportion of low to zero counts, and throughout has lower values than `pseudobulk_deseq`.
 
 
-Since these quantities here are so similar, remaining scatterplots will show only comparisons to `pseudobulk_deseq`.
 
 ### Compare pseudobulk to bulk
 
-We'd like to also get a sense of how this data compares to counts and TPM directly.
+Since these quantities here are so similar, these scatterplots will show only bulk comparisons to `pseudobulk_deseq`.
+
 These plots will show:
 
 * Left panel: `bulk TPM ~ pseudobulk_deseq`
@@ -232,9 +235,8 @@ make_binned_scatterplots <- function(df, project_id, nbins, facet_rows) {
     ggtitle("bulk_counts ~ deseq") 
 
 
-  patchwork::wrap_plots(p1, p2, ncol = 2) + patchwork::plot_annotation(title = project_id)  
+  patchwork::wrap_plots(p1, p2, ncol = 2) + patchwork::plot_annotation(title = project_id)
 }
-
 ```
 
 
@@ -242,7 +244,7 @@ make_binned_scatterplots <- function(df, project_id, nbins, facet_rows) {
 
 ```{r fig.height = 12, fig.width = 12, message=FALSE, warning=FALSE}
 make_binned_scatterplots(
-  project_wide_df_list$SCPCP000001, 
+  project_df_list$SCPCP000001, 
   project_id = "SCPCP000001",
   nbins = 15,
   facet_rows = 6
@@ -253,7 +255,7 @@ make_binned_scatterplots(
 
 ```{r fig.height = 10, fig.width = 12, message=FALSE, warning=FALSE}
 make_binned_scatterplots(
-  project_wide_df_list$SCPCP000002, 
+  project_df_list$SCPCP000002, 
   project_id = "SCPCP000002",
   nbins = 15,
   facet_rows = 6
@@ -263,7 +265,7 @@ make_binned_scatterplots(
 
 ```{r fig.height = 12, fig.width = 12, message=FALSE, warning=FALSE}
 make_binned_scatterplots(
-  project_wide_df_list$SCPCP000006, 
+  project_df_list$SCPCP000006, 
   project_id = "SCPCP000006",
   nbins = 15,
   facet_rows = 9
@@ -273,7 +275,7 @@ make_binned_scatterplots(
 
 ```{r fig.height = 3, fig.width = 12, message=FALSE, warning=FALSE}
 make_binned_scatterplots(
-  project_wide_df_list$SCPCP000009, 
+  project_df_list$SCPCP000009, 
   project_id = "SCPCP000009",
   nbins = 15,
   facet_rows = 1
@@ -283,7 +285,7 @@ make_binned_scatterplots(
 
 ```{r fig.height = 8, fig.width = 12, message=FALSE, warning=FALSE}
 make_binned_scatterplots(
-  project_wide_df_list$SCPCP000017, 
+  project_df_list$SCPCP000017, 
   project_id = "SCPCP000017",
   nbins = 40,
   facet_rows = 7
@@ -343,7 +345,7 @@ model_samples <- function(id, df) {
     )
 }
 
-stats_df <- project_wide_df_list |>
+stats_df <- project_df_list |>
   purrr::map(
     \(df) {
       
@@ -378,10 +380,10 @@ ggplot(stats_df) +
 ```
 
 * Relationships between pseudobulk and bulk counts are exceptionally similar here, and further we are generally lying along the 1:1 line.
-* For all projects, the nonparametric approach yields marginally higher correlations, but often marginally.
+* For all projects, the nonparametric approach yields marginally higher correlations, but often marginally
+* Using a nonparametric test yields stronger correlations for `bulk_counts` not but for `bulk_tpm`
 * For `SCPCP000001`, `SCPCP000002`, and `SCPCP000006`, the correlations are generally similar regardless of which quantities are being compared and which statistic is used, although there are some small differences (not likely significant)
 * For `SCPCP000009` (again, only 3 samples here!) and `SCPCP000017`, `bulk_counts` tends to outperform `bulk_tpm` for either pseudobulk measure
-* Using a nonparametric test does improve the relationship for `bulk_counts` not but for `bulk_tpm`
 
 The underlying correlations are here:
 
@@ -394,7 +396,7 @@ stats_df
 
 ## Disagreeing expression
 
-Currently this section does not include bulk counts, only bulk TPM.
+Based on performances of quantities above, this section considers specifically `bulk_counts` and `pseudobulk_log_counts`.
 
 Next, we'll take a quick look at cases where one modality has zero expression and the other doesn't.
 In these cases, if expression is generally high, we have evidence of disagreement/discrepancy between bulk and single-cell that may be interesting to investigate.
@@ -407,34 +409,17 @@ In this section, we'll also use a threshold of `1e-12` for zero here.
 
 
 ```{r fig.height=10, fig.width=12, message=FALSE, warning=FALSE}
-project_wide_df_list |>
-  purrr::map(
-    \(df) {
-      
-      low_deseq <- df |>
-        dplyr::filter(pseudobulk_deseq <= 1e-12, 
-                      bulk_tpm > 1e-12)
-      low_logcounts <- df |>
-        dplyr::filter(pseudobulk_log_counts <= 1e-12, 
-                      bulk_tpm > 1e-12)  
-
-      
-      p1 <- ggplot(low_deseq) + 
-        aes(x = sample_id, y = bulk_tpm) + 
-        ggforce::geom_sina(size = 0.5) +
-        theme(axis.text.x = element_blank()) +
-        ggtitle("TPM for zero & negative pseudobulk_deseq")
+plot_df <- purrr::list_rbind(project_df_list, names_to = "project_id") |>
+  dplyr::filter(
+    pseudobulk_log_counts <= 1e-12, 
+    bulk_counts > 1e-12
+  )  
   
-      p2 <- ggplot(low_logcounts) + 
-        aes(x = sample_id, y = bulk_tpm) + 
-        ggforce::geom_sina(size = 0.5) +
-        theme(axis.text.x = element_blank()) +
-        ggtitle("TPM for zero pseudobulk_log_counts")
-      
-      patchwork::wrap_plots(p1, p2, nrow = 1)
-    }
-  ) |>
-  patchwork::wrap_plots(ncol = 1)
+ggplot(plot_df) + 
+  aes(x = sample_id, y = bulk_counts) + 
+  geom_boxplot(outlier.size = 0.25) +
+  facet_wrap(vars(project_id), ncol = 1, scale = "free") +
+  theme(axis.text.x = element_blank())
 ```
 
 
@@ -442,73 +427,25 @@ project_wide_df_list |>
 ### Single-cell when bulk TPM is zero
 
 
-
-```{r fig.height=12, fig.width=12, message=FALSE, warning=FALSE}
-project_wide_df_list |>
-  purrr::imap(
-    \(df, project_id) {
-      
-      low_bulk <- df |>
-        # Even though we don't have 1:1 correspondence between pseudobulks here,
-        #  we'll just consider only points where neither is 0 to get a sense.
-        dplyr::filter(bulk_tpm <= 1e-12, 
-                      pseudobulk_deseq> 1e-12, 
-                      pseudobulk_log_counts> 1e-12) |>
-        tidyr::pivot_longer(
-          contains("pseudobulk"), 
-          names_to = "expression_type", 
-          values_to = "expression"
-        )
-      
-      ggplot(low_bulk) + 
-        aes(x = sample_id, y = expression, color = expression_type) + 
-        ggforce::geom_sina(size = 0.5) +
-        theme(axis.text.x = element_blank()) +
-        ggtitle(project_id)
-
-    }
-  ) |>
-  patchwork::wrap_plots(ncol = 1, guides = "collect")
+```{r fig.height=10, fig.width=12, message=FALSE, warning=FALSE}
+plot_df <- purrr::list_rbind(project_df_list, names_to = "project_id") |>
+  dplyr::filter(
+    bulk_counts <= 1e-12, 
+    pseudobulk_log_counts > 1e-12
+  )  
+  
+ggplot(plot_df) + 
+  aes(x = sample_id, y = pseudobulk_log_counts) + 
+  geom_boxplot(outlier.size = 0.25) +
+  facet_wrap(vars(project_id), ncol = 1, scale = "free") +
+  theme(axis.text.x = element_blank())
 ```
 
 
 
-From both comparisons, there are a fair number of genes with high expression in one modality and essentially zero in the other. 
+From both comparisons, there's a decent number of genes with high expression in one modality and essentially zero in the other. 
 A more careful investigation here look into what exactly these genes are, and whether they have some biological relationship that might suggest modalities are picking up different information.
 
-
-### Do pseudobulks have strong disagreements?
-
-This will show genes strongly affected by different preparation/normalization approaches.
-
-
-```{r fig.height=12, fig.width=12, message=FALSE, warning=FALSE}
-project_wide_df_list |>
-  purrr::imap(
-    \(df, project_id) {
-      
-      different_low_pseudo <- df |>
-        dplyr::filter((pseudobulk_deseq> 1e-12 & pseudobulk_log_counts <= 1e-12) |
-                       (pseudobulk_deseq <=1e-12 & pseudobulk_log_counts > 1e-12) ) |>
-        tidyr::pivot_longer(
-          contains("pseudobulk"), 
-          names_to = "expression_type", 
-          values_to = "expression"
-        )
-      
-      ggplot(different_low_pseudo) + 
-        aes(x = sample_id, y = expression, color = expression_type) + 
-        ggforce::geom_sina(size = 0.5) +
-        theme(axis.text.x = element_blank()) +
-        ggtitle(project_id)
-
-
-    }
-  ) |>
-  patchwork::wrap_plots(ncol = 1, guides = "collect")
-```
-
-Most values seem to be `[-2.5, 2.5]` for both pseudobulks, but some are getting as high as 6-9. 
 
 
 ## Session info

--- a/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
+++ b/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Pseudobulk and bulk data distributions"
+title: "Initial exploration and comparison of pseudobulk vs. bulk expression"
 author: Stephanie J. Spielman
 date: "`r Sys.Date()`"
 output:
@@ -10,7 +10,7 @@ output:
 ---
 
 The goal of this notebook is to compare pseudobulk and bulk calculations to determine which pseudobulk calculation should we proceed with for modeling: the log2 of the sum of raw counts (`pseudobulk_log_counts`) or the `DESeq2`-normalized sum of raw counts (`pseudobulk_deseq`).
-To this end, we'll visualize expression distributions, both on their own and compared to bulk TPM. 
+To this end, we'll explore pseudobulk expression distributions, compare them to bulk, and also explore distributions of expression where there is disagreement between bulk and single-cell.
 
 
 ## Setup
@@ -344,7 +344,7 @@ project_wide_df_list |>
         aes(x = sample_id, y = bulk_tpm) + 
         ggforce::geom_sina(size = 0.5) +
         theme(axis.text.x = element_blank()) +
-        ggtitle("TPM for zero & negative pesudobulk_deseq")
+        ggtitle("TPM for zero & negative pseudobulk_deseq")
   
       p2 <- ggplot(low_logcounts) + 
         aes(x = sample_id, y = bulk_tpm) + 

--- a/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
+++ b/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
@@ -315,6 +315,122 @@ stats_df
 ```
 
 
+## Disagreeing expression
+
+Next, we'll take a quick look at cases where one modality has zero expression and the other doesn't.
+In these cases, if expression is generally high, we have evidence of disagreement/discrepancy between bulk and single-cell that may be interesting to investigate.
+In this notebook, we'll just a sense of how much "there is there," and we'll leave the in-depth look into any such genes for a subsequent notebook.
+
+In this section, we'll also use a threshold of `1e-12` for zero here.
+
+
+### Bulk TPM when single-cell is zero
+
+
+```{r fig.height=10, fig.width=12, message=FALSE, warning=FALSE}
+project_wide_df_list |>
+  purrr::map(
+    \(df) {
+      
+      low_deseq <- df |>
+        dplyr::filter(pseudobulk_deseq <= 1e-12, 
+                      bulk_tpm > 1e-12)
+      low_logcounts <- df |>
+        dplyr::filter(pseudobulk_log_counts <= 1e-12, 
+                      bulk_tpm > 1e-12)  
+
+      
+      p1 <- ggplot(low_deseq) + 
+        aes(x = sample_id, y = bulk_tpm) + 
+        ggforce::geom_sina(size = 0.5) +
+        theme(axis.text.x = element_blank()) +
+        ggtitle("TPM for zero & negative pesudobulk_deseq")
+  
+      p2 <- ggplot(low_logcounts) + 
+        aes(x = sample_id, y = bulk_tpm) + 
+        ggforce::geom_sina(size = 0.5) +
+        theme(axis.text.x = element_blank()) +
+        ggtitle("TPM for zero pseudobulk_log_counts")
+      
+      patchwork::wrap_plots(p1, p2, nrow = 1)
+    }
+  ) |>
+  patchwork::wrap_plots(ncol = 1)
+```
+
+
+
+### Single-cell when bulk TPM is zero
+
+Even though we don't have 1:1 correspondance between pseudobulks here, we'll just consider only points where neither is 0 to get a sense.
+This isn't final.
+
+```{r fig.height=12, fig.width=12, message=FALSE, warning=FALSE}
+project_wide_df_list |>
+  purrr::imap(
+    \(df, project_id) {
+      
+      low_bulk <- df |>
+        dplyr::filter(bulk_tpm <= 1e-12, 
+                      pseudobulk_deseq> 1e-12, 
+                      pseudobulk_log_counts> 1e-12) |>
+        tidyr::pivot_longer(
+          contains("pseudobulk"), 
+          names_to = "expression_type", 
+          values_to = "expression"
+        )
+      
+      ggplot(low_bulk) + 
+        aes(x = sample_id, y = expression, color = expression_type) + 
+        ggforce::geom_sina(size = 0.5) +
+        theme(axis.text.x = element_blank()) +
+        ggtitle(project_id)
+
+    }
+  ) |>
+  patchwork::wrap_plots(ncol = 1, guides = "collect")
+```
+
+
+
+From both comparisons, there are a fair number of genes with high expression in one modality and essentially zero in the other. 
+A more careful investigation here look into what exactly these genes are, and whether they have some biological relationship that might suggest modalities are picking up different information.
+
+
+### Do pseudobulks have strong disagreements?
+
+This will show genes strongly affected by different normalizations.
+
+
+```{r fig.height=12, fig.width=12, message=FALSE, warning=FALSE}
+project_wide_df_list |>
+  purrr::imap(
+    \(df, project_id) {
+      
+      different_low_pseudo <- df |>
+        dplyr::filter((pseudobulk_deseq> 1e-12 & pseudobulk_log_counts <= 1e-12) |
+                       (pseudobulk_deseq <=1e-12 & pseudobulk_log_counts > 1e-12) ) |>
+        tidyr::pivot_longer(
+          contains("pseudobulk"), 
+          names_to = "expression_type", 
+          values_to = "expression"
+        )
+      
+      ggplot(different_low_pseudo) + 
+        aes(x = sample_id, y = expression, color = expression_type) + 
+        ggforce::geom_sina(size = 0.5) +
+        theme(axis.text.x = element_blank()) +
+        ggtitle(project_id)
+
+
+    }
+  ) |>
+  patchwork::wrap_plots(ncol = 1, guides = "collect")
+```
+
+Most values seem to be `[-2.5, 2.5]` for both pseudobulks, but some are getting as high as 6-9. 
+
+
 ## Session info
 
 ```{r}

--- a/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
+++ b/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
@@ -110,7 +110,7 @@ bulk_counts_wide_df_list <- readr::read_rds(bulk_counts_file) |>
 ```
 
 
-Bind it up for later comparisons:
+Combine `bulk_counts` data with the full data frame lists (not the most efficient but gets it done!):
 
 ```{r}
 project_wide_df_list <- purrr::map2(
@@ -122,6 +122,19 @@ project_wide_df_list <- purrr::map2(
       dplyr::left_join(df_counts, by = c("ensembl_id", "sample_id"))
   }
 )
+
+project_long_df_list <- purrr::map2(
+  bulk_counts_wide_df_list, 
+  project_long_df_list, 
+  \(df_counts, df_main) {
+    
+    df_counts |>
+      dplyr::rename(expression = bulk_counts) |>
+      dplyr::mutate(expression_type = "bulk_counts") |>
+      dplyr::bind_rows(df_main)
+    
+  })
+  
 ```
 
 
@@ -129,7 +142,7 @@ project_wide_df_list <- purrr::map2(
 
 First, we'll visualize distributions of all quantities:
 
-```{r, fig.width = 7, fig.height = 5, warning = FALSE}
+```{r, fig.width = 7, fig.height = 7, warning = FALSE}
 ggplot(purrr::list_rbind(project_long_df_list, names_to = "project_id")) + 
   aes(x = expression, fill = expression_type) + 
   geom_density(alpha = 0.5) + 
@@ -145,6 +158,7 @@ ggplot(purrr::list_rbind(project_long_df_list, names_to = "project_id")) +
 We see big spikes at zero for pseudobulk, not surprisingly.
 Due to the different transformation approaches, the `pseudobulk_deseq` version has some negatives for fractional values, but the other quantities have a lower bound of zero.
 All around, distributions range from their lower bound up to around 20, so it's nice to know pseudobulk and bulk are definitely on the same scale.
+In the bulk counts, `SCPCP000017` seems to have a much larger peak at zero compared to other projects.
 
   
 ## Relationship between quantities
@@ -188,34 +202,39 @@ These quantities are exceptionally similar with these differences:
 * In a handful of samples (1-2 per project), `pseudobulk_log_counts` appears to have a higher proportion of low to zero counts, and throughout has lower values than `pseudobulk_deseq`.
 
 
-### Compare pseudobulk to bulk counts
+Since these quantities here are so similar, remaining scatterplots will show only comparisons to `pseudobulk_deseq`.
 
-We'd like to also get a sense of how this data compares to counts directly.
+### Compare pseudobulk to bulk
 
+We'd like to also get a sense of how this data compares to counts and TPM directly.
+These plots will show:
+
+* Left panel: `bulk TPM ~ pseudobulk_deseq`
+* Right panel: `bulk counts ~ pseudobulk_deseq`
 
 ```{r}
 # Helper function to visualize scatterplots with geom_bin_2d()
-make_binned_scatterplots <- function(df, project_id, yvar, nbins, facet_rows) {
+make_binned_scatterplots <- function(df, project_id, nbins, facet_rows) {
   p1 <- ggplot(df) + 
-    aes(x = pseudobulk_deseq, y = {{yvar}}) + 
+    aes(x = pseudobulk_deseq, y = bulk_tpm) + 
     geom_bin_2d(bins = nbins) + 
     geom_smooth(method = "lm", alpha = 0.8, linewidth = 0.5) +
     geom_abline(alpha = 0.8, linewidth = 0.5, color = "red") + 
     facet_wrap(vars(sample_id), nrow = facet_rows) +
-    ggtitle("~ deseq") 
-    
+    ggtitle("bulk_tpm ~ deseq") 
+  
   p2 <- ggplot(df) + 
-    aes(x = pseudobulk_log_counts, y = {{yvar}}) + 
+    aes(x = pseudobulk_deseq, y = bulk_counts) + 
     geom_bin_2d(bins = nbins) + 
     geom_smooth(method = "lm", alpha = 0.8, linewidth = 0.5) +
     geom_abline(alpha = 0.8, linewidth = 0.5, color = "red") + 
     facet_wrap(vars(sample_id), nrow = facet_rows) +
-    ggtitle("~ log_counts") 
-      
-  print(
-    patchwork::wrap_plots(p1, p2, ncol = 2) + patchwork::plot_annotation(title = project_id)
-  )
+    ggtitle("bulk_counts ~ deseq") 
+
+
+  patchwork::wrap_plots(p1, p2, ncol = 2) + patchwork::plot_annotation(title = project_id)  
 }
+
 ```
 
 
@@ -225,7 +244,6 @@ make_binned_scatterplots <- function(df, project_id, yvar, nbins, facet_rows) {
 make_binned_scatterplots(
   project_wide_df_list$SCPCP000001, 
   project_id = "SCPCP000001",
-  yvar = bulk_counts,
   nbins = 15,
   facet_rows = 6
 )
@@ -237,7 +255,6 @@ make_binned_scatterplots(
 make_binned_scatterplots(
   project_wide_df_list$SCPCP000002, 
   project_id = "SCPCP000002",
-  yvar = bulk_counts,
   nbins = 15,
   facet_rows = 6
 )
@@ -248,7 +265,6 @@ make_binned_scatterplots(
 make_binned_scatterplots(
   project_wide_df_list$SCPCP000006, 
   project_id = "SCPCP000006",
-  yvar = bulk_counts,
   nbins = 15,
   facet_rows = 9
 )
@@ -259,7 +275,6 @@ make_binned_scatterplots(
 make_binned_scatterplots(
   project_wide_df_list$SCPCP000009, 
   project_id = "SCPCP000009",
-  yvar = bulk_counts,
   nbins = 15,
   facet_rows = 1
 )
@@ -270,185 +285,62 @@ make_binned_scatterplots(
 make_binned_scatterplots(
   project_wide_df_list$SCPCP000017, 
   project_id = "SCPCP000017",
-  yvar = bulk_counts,
   nbins = 40,
   facet_rows = 7
 )
 ```
 
-
-
-
-#### Statistics
-
-Let's now get some stats for the comparison between bulk counts and pseudobulk.
-We'll fit a linear model for each sample, and display some quantities below both as boxplots and the full table.
-
-```{r fig.height = 10, fig.width = 12}
-# Helper functions to plot model statistics from data frame
-plot_stats <- function(df, column, title) {
-  ggplot(df) + 
-    aes(x = expression_type, y = {{column}}, color = expression_type) + 
-    geom_boxplot() + 
-    scale_color_brewer(palette = "Dark2") +
-    ggtitle(title) +
-    facet_wrap(vars(project_id), nrow = 1) +
-    theme(legend.position = "none")
-}
-
-model_samples_counts <- function(id, df) {
-  sample_df <- df |>
-    dplyr::filter(sample_id == id) 
-  
-  df_deseq <- sample_df |>
-    dplyr::filter(is.finite(pseudobulk_deseq), is.finite(bulk_counts))
-  fit_deseq <- summary(lm(bulk_counts ~ pseudobulk_deseq, data = df_deseq))
-
-  df_log_counts <- sample_df |>
-      dplyr::filter(is.finite(pseudobulk_log_counts), is.finite(bulk_counts))
-  fit_log_counts <- summary(lm(bulk_counts ~ pseudobulk_log_counts, data = df_log_counts))
-      
-  # Tabulate and return some fit stats
-  data.frame(
-    expression_type = c("deseq", "log_counts"),
-    rsquared = c(fit_deseq$r.squared, fit_log_counts$r.squared), 
-    coeff = c(fit_deseq$coefficients[2], fit_log_counts$coefficients[2]), 
-    residual_sd = c(fit_deseq$sigma,  fit_log_counts$sigma)
-  )
-}
-
-stats_df <- project_wide_df_list |>
-  purrr::map(
-    \(df) {
-      
-      # We need to map over sample ids now
-      samples <- unique(df$sample_id)
-      names(samples) <- samples
-      
-      fit_table <- samples |>
-        purrr::map(model_samples_counts, df) |>
-        purrr::list_rbind(names_to = "sample_id")
-      
-      return(fit_table)
-
-    }
-  ) |>
-  # now, combine all projects into a single table
-  purrr::list_rbind(names_to = "project_id")
-
-patchwork::wrap_plots(
-  plot_stats(stats_df, rsquared, "rsquared"),
-  plot_stats(stats_df, coeff, "coeff"), 
-  plot_stats(stats_df, residual_sd, "residual_sd"), 
-  nrow = 3
-) 
-```
-
-* Relationships between pseudobulk and bulk counts are exceptionally similar here, and further we are generally lying along the 1:1 line.
-* `SCPCP000001` and `SCPCP000002` have some outlying samples where `log_counts` performs worse, which are likely the cases we see in the scatterplots where the relationship with `log_counts` shows bias relative to `y=x`
-* Relationships are strongest for`SCPCP000001` and `SCPCP000002`, then `SCPCP000006`, then `SCPCP000009`, and finally `SCPCP000017` whose relationship is weak if at all present.
-* Samples within a given project have broadly similar coefficients, with a few outliers, suggesting less of an interaction among samples/expression than one might have thought.
-`SCPCP000017` does have more variation here, but also the relationship is very weak in the first place so these different coefficients are not necessarily statistically significantly different.
-
-All the actual values are here:
-
-
-```{r}
-stats_df
-```
-
-
-
-### Compare pseudobulk to bulk TPM
-
-
-Now we'll do the same for pseudobulk and bulk TPM
-
-```{r fig.height = 12, fig.width = 12, message=FALSE, warning=FALSE}
-make_binned_scatterplots(
-  project_wide_df_list$SCPCP000001, 
-  project_id = "SCPCP000001",
-  yvar = bulk_tpm,
-  nbins = 40,
-  facet_rows = 6
-)
-```
-
-
-
-```{r fig.height = 10, fig.width = 12, message=FALSE, warning=FALSE}
-make_binned_scatterplots(
-  project_wide_df_list$SCPCP000002, 
-  project_id = "SCPCP000002",
-  yvar = bulk_tpm,
-  nbins = 30,
-  facet_rows = 6
-)
-```
-
-
-```{r fig.height = 12, fig.width = 12, message=FALSE, warning=FALSE}
-make_binned_scatterplots(
-  project_wide_df_list$SCPCP000006, 
-  project_id = "SCPCP000006",
-  yvar = bulk_tpm,
-  nbins = 50,
-  facet_rows = 9
-)
-```
-
-
-```{r fig.height = 3, fig.width = 12, message=FALSE, warning=FALSE}
-make_binned_scatterplots(
-  project_wide_df_list$SCPCP000009, 
-  project_id = "SCPCP000009",
-  yvar = bulk_tpm,
-  nbins = 15,
-  facet_rows = 1
-)
-```
-
-
-```{r fig.height = 8, fig.width = 12, message=FALSE, warning=FALSE}
-make_binned_scatterplots(
-  project_wide_df_list$SCPCP000017, 
-  project_id = "SCPCP000017",
-  yvar = bulk_tpm,
-  nbins = 40,
-  facet_rows = 7
-)
-```
-
-We see high concentrations of points around `(0,0`) as well as towards the middle values across plots.
-Next, we'll look at regression stats for these plots directly.
+* `bulk_counts` generally has much closer to a 1:1 relationship with pseudobulk compared to `bulk_tpm`
+  * This is nearly universally the case for `SCPCP000001`, `SCPCP000002`, and `SCPCP000006`, and while true for `SCPCP000009` and `SCPCP000017`, it is less pronounced
+* Relationships in general are weakest for `SCPCP000017`, but the situation does look better with `bulk_counts`
 
 
 #### Statistics
 
-Let's now get some stats for the comparison between bulk TPM and pseudobulk.
-We'll fit a linear model for each sample, and display some quantities below both as boxplots and the full table.
+Let's nail this down further with correlations comparing each measure for bulk with each measure for pseudobulk.
+We'll perform correlations on a per-sample basis, both parametric and non-parametric, display some correlations below both as boxplots and the full table.
 
-```{r fig.height = 10, fig.width = 12}
+```{r fig.height = 10, fig.width = 8}
 
-model_samples_tpm <- function(id, df) {
+# Helper function to run correlations
+model_samples <- function(id, df) {
   sample_df <- df |>
     dplyr::filter(sample_id == id) 
   
+  #### Bulk tpm
   df_deseq <- sample_df |>
     dplyr::filter(is.finite(pseudobulk_deseq), is.finite(bulk_tpm))
-  fit_deseq <- summary(lm(bulk_tpm ~ pseudobulk_deseq, data = df_deseq))
+  r_deseq_tpm <- cor(df_deseq$bulk_tpm, df_deseq$pseudobulk_deseq, method = "spearman")
+  rho_deseq_tpm <- cor(df_deseq$bulk_tpm, df_deseq$pseudobulk_deseq, method = "pearson")
 
   df_log_counts <- sample_df |>
       dplyr::filter(is.finite(pseudobulk_log_counts), is.finite(bulk_tpm))
-  fit_log_counts <- summary(lm(bulk_tpm ~ pseudobulk_log_counts, data = df_log_counts))
+  r_logcounts_tpm <- cor(df_deseq$bulk_tpm, df_deseq$pseudobulk_log_counts, method = "spearman")
+  rho_logcounts_tpm <- cor(df_deseq$bulk_tpm, df_deseq$pseudobulk_log_counts, method = "pearson")
+      
+  #### Bulk counts
+  df_deseq <- sample_df |>
+    dplyr::filter(is.finite(pseudobulk_deseq), is.finite(bulk_counts))
+  r_deseq_counts <- cor(df_deseq$bulk_counts, df_deseq$pseudobulk_deseq, method = "spearman")
+  rho_deseq_counts <- cor(df_deseq$bulk_counts, df_deseq$pseudobulk_deseq, method = "pearson")
+
+  df_log_counts <- sample_df |>
+      dplyr::filter(is.finite(pseudobulk_log_counts), is.finite(bulk_counts))
+  r_logcounts_counts <- cor(df_deseq$bulk_counts, df_deseq$pseudobulk_log_counts, method = "spearman")
+  rho_logcounts_counts <- cor(df_deseq$bulk_counts, df_deseq$pseudobulk_log_counts, method = "pearson")
       
   # Tabulate and return some fit stats
   data.frame(
-    expression_type = c("deseq", "log_counts"),
-    rsquared = c(fit_deseq$r.squared, fit_log_counts$r.squared), 
-    coeff = c(fit_deseq$coefficients[2], fit_log_counts$coefficients[2]), 
-    residual_sd = c(fit_deseq$sigma,  fit_log_counts$sigma)
-  )
+    r =      c(r_deseq_tpm,    r_logcounts_tpm,    r_deseq_counts,   r_logcounts_counts),
+    rho =    c(rho_deseq_tpm,  rho_logcounts_tpm,  rho_deseq_counts, rho_logcounts_counts),
+    bulk =   c("bulk_tpm",    "bulk_tpm",          "bulk_counts",    "bulk_counts"), 
+    pseudo = c("deseq",       "log_counts",        "deseq",          "log_counts")
+  ) |>
+    tidyr::pivot_longer(
+      c(r, rho), 
+      names_to = "measure", 
+      values_to = "correlation"
+    )
 }
 
 stats_df <- project_wide_df_list |>
@@ -460,7 +352,7 @@ stats_df <- project_wide_df_list |>
       names(samples) <- samples
       
       fit_table <- samples |>
-        purrr::map(model_samples_tpm, df) |>
+        purrr::map(model_samples, df) |>
         purrr::list_rbind(names_to = "sample_id")
       
       return(fit_table)
@@ -468,27 +360,36 @@ stats_df <- project_wide_df_list |>
     }
   ) |>
   # now, combine all projects into a single table
-  purrr::list_rbind(names_to = "project_id")
+  purrr::list_rbind(names_to = "project_id") |>
+  dplyr::mutate(comparison = glue::glue("{bulk}-{pseudo}")) |>
+  dplyr::select(-bulk, -pseudo)
 
-patchwork::wrap_plots(
-  plot_stats(stats_df, rsquared, "rsquared"),
-  plot_stats(stats_df, coeff, "coeff"), 
-  plot_stats(stats_df, residual_sd, "residual_sd"), 
-  nrow = 3
-) 
+
+ggplot(stats_df) + 
+  aes(x = comparison, fill = comparison, y = correlation) + 
+  geom_boxplot(linewidth = 0.25, outlier.size = 0.25)+
+  facet_grid(
+    rows = vars(project_id), 
+    cols = vars(measure)) + 
+  theme(
+    legend.position = "none", 
+    axis.text.x = element_text(angle = 30, hjust = 1)
+  )
 ```
 
-* Pseudobulk quantities are exceptionally similar here, which isn't necessarily surprising given the similarity of the pseudobulk measures
-* Relationships are strongest for`SCPCP000001` and `SCPCP000002`, then `SCPCP000006`, then `SCPCP000009`, and finally `SCPCP000017` whose relationship is weak if at all present.
-* Samples within a given project have broadly similar coefficients, with a few outliers, suggesting less of an interaction among samples/expression than one might have thought.
-`SCPCP000017` does have more variation here, but also the relationship is very weak in the first place so these different coefficients are not necessarily statistically significantly different.
+* Relationships between pseudobulk and bulk counts are exceptionally similar here, and further we are generally lying along the 1:1 line.
+* For all projects, the nonparametric approach yields marginally higher correlations, but often marginally.
+* For `SCPCP000001`, `SCPCP000002`, and `SCPCP000006`, the correlations are generally similar regardless of which quantities are being compared and which statistic is used, although there are some small differences (not likely significant)
+* For `SCPCP000009` (again, only 3 samples here!) and `SCPCP000017`, `bulk_counts` tends to outperform `bulk_tpm` for either pseudobulk measure
+* Using a nonparametric test does improve the relationship for `bulk_counts` not but for `bulk_tpm`
 
-All the actual values are here:
+The underlying correlations are here:
 
 
 ```{r}
 stats_df
 ```
+
 
 
 ## Disagreeing expression

--- a/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
+++ b/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
@@ -34,7 +34,7 @@ pseudobulk_dir <- file.path(data_dir, "pseudobulk")
 tpm_files <- list.files(
   path = tpm_dir,
   full.names = TRUE,
-  pattern = "*-tpm.tsv$"
+  pattern = "-tpm\\.tsv$"
 )
 tpm_names <- stringr::str_split_i(basename(tpm_files), pattern = "-", i = 1)
 names(tpm_files) <- tpm_names
@@ -43,7 +43,7 @@ names(tpm_files) <- tpm_names
 pseudobulk_files <- list.files(
   path = pseudobulk_dir,
   full.names = TRUE,
-  pattern = "*-pseudobulk.rds$"
+  pattern = "-pseudobulk\\.tsv$"
 )
 pseudobulk_names <- stringr::str_split_i(basename(pseudobulk_files), pattern = "-", i = 1)
 names(pseudobulk_files) <- pseudobulk_names
@@ -56,70 +56,30 @@ stopifnot(
 
 ### Read and prepare input data
 
-
-Data are saved as matrices, so we'll convert them to per-project long data frames here. 
+We'll make both a long and wide version of the data for each project.
 
 ```{r}
-tpm_df_list <- tpm_files |>
-  purrr::map(
-    \(tpm_file) {
-      readr::read_tsv(tpm_file, show_col_types = FALSE) |>
-        tidyr::pivot_longer(
-          -ensembl_id, 
-          names_to = "sample_id", 
-          values_to = "expression"
-        ) |>
-        dplyr::mutate(expression_type = "bulk_tpm")   
-   }
-  )
-
-project_df_list <- purrr::map2(
+project_long_df_list <- purrr::map2(
+  tpm_files, 
   pseudobulk_files, 
-  tpm_df_list,
-  \(pseudo_file, tpm_df) {
+  \(tpm_file, pseudo_file) {
     
-    pseudo_list <- readr::read_rds(pseudo_file)
-    
-    # Filter tpm_df for genes in the pseudobulk
-    tpm_filtered_df <- tpm_df |>
-      dplyr::filter(ensembl_id %in% rownames(pseudo_list[[1]]))
-      
-    # combine pseudobulk matrices into a long data frame and bind with tpm
-    combined_df_long <- pseudo_list |>
-      purrr::map(
-        \(mat) {
-          mat |>
-            as.data.frame() |> 
-            tibble::rownames_to_column("ensembl_id") |> 
-            tidyr::pivot_longer(
-              -ensembl_id, 
-              names_to = "sample_id", 
-              values_to = "expression"
-            )
-        }
-      ) |>
-      purrr::list_rbind(names_to = "expression_type") |> 
-      dplyr::bind_rows(tpm_filtered_df) |>
-      dplyr::select(sample_id, ensembl_id, expression, expression_type)
+    dplyr::bind_rows(
+      readr::read_tsv(tpm_file, show_col_types = FALSE),
+      readr::read_tsv(pseudo_file, show_col_types = FALSE)
+    )
   }
 )
 
-shared_genes <- purrr::map(
-  project_df_list, 
-  \(df) df$ensembl_id
+# Make a wide version as well
+project_wide_df_list <- project_long_df_list |>
+  purrr::map(
+    \(df) {
+      df |>
+        tidyr::pivot_wider(names_from = expression_type, values_from = expression)
+    }
 )
-
-tpm_df_indicator_list <- purrr::map2(
-  tpm_df_list,
-  shared_genes,
-  \(df, ids) dplyr::mutate(df, in_pseudo = ensembl_id %in% ids)
-  )
-
-# clean up!
-rm(shared_genes)
-rm(tpm_df_list)
 ```
-
 
 
 ## Bulk TPM distributions

--- a/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
+++ b/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
@@ -116,41 +116,126 @@ This section will look at the relationship between bulk and pseudobulk quantitie
   * these results are presented both as plots and as the full per-sample table to scroll through
   
   
+  
+## Relationship between quantities
+
+This section will look at the relationship among quantities.
+
+  
 ### Scatterplots 
 
-What does the relationship look like between bulk and each flavor of pseudobulk?
-Plots are organized by project and:
+First, we'll look at some scatterplots:
 
-* Left-side panels are `bulk tpm ~ deseq pseudocounts`
-* Right-side panels are `bulk tpm ~ log_counts pseudocounts`
+* How similar are the pseudobulk measures themselves?
+* How does each pseudobulk measure compare to bulk?
+  * For these plots, we'll bin data to see the concentration of overlapping points more easily.
 
-```{r fig.height=35, fig.width=18, message=FALSE, warning=FALSE}
+In all plots, the red line is `y=x`, and the blue line is the regression line.
+
+#### Compare pseudobulk measures
+
+```{r fig.height=28, fig.width=12, message=FALSE, warning=FALSE}
 project_wide_df_list |>
   purrr::imap(
     \(df, project_id) {
       
-      p1 <- ggplot(df) + 
-        aes(x = pseudobulk_deseq, y = bulk_tpm) + 
+      ggplot(df) + 
+        aes(x = pseudobulk_deseq, y = pseudobulk_log_counts) + 
         geom_point(alpha = 0.2, size = 0.5) + 
-        geom_smooth(method = "lm") + 
+        geom_smooth(method = "lm", linewidth = 0.5) +
+        geom_abline(linewidth = 0.5, color = "red") + 
         facet_wrap(vars(sample_id), nrow = 5) +
-        ggtitle("bulk tpm ~ deseq")
-      
-      p2 <- ggplot(df) + 
-        aes(x = pseudobulk_log_counts, y = bulk_tpm) + 
-        geom_point(alpha = 0.2, size = 0.5) + 
-        geom_smooth(method = "lm") +
-        facet_wrap(vars(sample_id), nrow = 5) +
-        ggtitle("bulk tpm ~ logcounts") 
-           
-      
-      patchwork::wrap_plots(p1, p2) 
+        ggtitle("log_counts ~ deseq") 
 
     }
   ) |>
   patchwork::wrap_plots(ncol = 1)
 ```
 
+
+These quantities are exceptionally similar with these differences:
+
+* Driven by different normalization approaches, genes with very low to zero expression
+* In a handful of sampels (1-2 per project), `pseudobulk_log_counts` appears to have a higher proportion of low to zero counts, and throughout has markedly lower values compares to `pseudobulk_deseq`.
+
+
+#### Compare pseudobulk to bulk
+
+To make sure we get a good view, we'll first make the plots and then show them per project with their plot settings.
+
+```{r}
+# Helper function to visualize scatterplots with geom_bin_2d()
+make_binned_scatterplots <- function(df, project_id, facet_rows) {
+  p1 <- ggplot(df) + 
+    aes(x = pseudobulk_deseq, y = bulk_tpm) + 
+    geom_bin_2d(bins = 12) + # signal mostly starts to wash out after this
+    geom_smooth(method = "lm", alpha = 0.8, linewidth = 0.5) +
+    geom_abline(alpha = 0.8, linewidth = 0.5, color = "red") + 
+    facet_wrap(vars(sample_id), nrow = facet_rows) +
+    ggtitle("bulk_tpm ~ deseq") 
+    
+  p2 <- ggplot(df) + 
+    aes(x = pseudobulk_log_counts, y = bulk_tpm) + 
+    geom_bin_2d(bins = 12) +
+    geom_smooth(method = "lm", alpha = 0.8, linewidth = 0.5) +
+    geom_abline(alpha = 0.8, linewidth = 0.5, color = "red") + 
+    facet_wrap(vars(sample_id), nrow = facet_rows) +
+    ggtitle("bulk_tpm ~ log_counts") 
+      
+  print(
+    patchwork::wrap_plots(p1, p2, ncol = 2) + patchwork::plot_annotation(title = project_id)
+  )
+}
+```
+
+
+```{r fig.height = 8, fig.width = 12, message=FALSE, warning=FALSE}
+make_binned_scatterplots(
+  project_wide_df_list$SCPCP000001, 
+  project_id = "SCPCP000001",
+  facet_rows = 6
+)
+```
+
+
+
+```{r fig.height = 8, fig.width = 12, message=FALSE, warning=FALSE}
+make_binned_scatterplots(
+  project_wide_df_list$SCPCP000002, 
+  project_id = "SCPCP000002",
+  facet_rows = 6
+)
+```
+
+
+```{r fig.height = 8, fig.width = 12, message=FALSE, warning=FALSE}
+make_binned_scatterplots(
+  project_wide_df_list$SCPCP000006, 
+  project_id = "SCPCP000006",
+  facet_rows = 9
+)
+```
+
+
+```{r fig.height = 3, fig.width = 12, message=FALSE, warning=FALSE}
+make_binned_scatterplots(
+  project_wide_df_list$SCPCP000009, 
+  project_id = "SCPCP000009",
+  facet_rows = 1
+)
+```
+
+
+```{r fig.height = 8, fig.width = 12, message=FALSE, warning=FALSE}
+make_binned_scatterplots(
+  project_wide_df_list$SCPCP000017, 
+  project_id = "SCPCP000017",
+  facet_rows = 7
+)
+```
+
+
+Points are fairly evenly distributed across the scatterplot, except for a very high concentration of points at `0,0` (and into the negatives for `pseudobulk_deseq`). 
 
 ### Statistics 
 

--- a/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
+++ b/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/pseudobulk-calculations.Rmd
@@ -133,7 +133,7 @@ project_df_list <- purrr::map2(
 
 First, we'll visualize distributions of all quantities:
 
-```{r, fig.width = 7, fig.height = 7, warning = FALSE}
+```{r, fig.width = 7, fig.height = 6.5, warning = FALSE}
 plot_df <- project_df_list |>
   purrr::list_rbind(names_to = "project_id") |> 
   tidyr::pivot_longer(
@@ -302,7 +302,7 @@ make_binned_scatterplots(
 Let's nail this down further with correlations comparing each measure for bulk with each measure for pseudobulk.
 We'll perform correlations on a per-sample basis, both parametric and non-parametric, display some correlations below both as boxplots and the full table.
 
-```{r fig.height = 10, fig.width = 8}
+```{r fig.height = 10, fig.width = 6}
 
 # Helper function to run correlations
 model_samples <- function(id, df) {
@@ -405,7 +405,7 @@ In this notebook, we'll just a sense of how much "there is there," and we'll lea
 In this section, we'll also use a threshold of `1e-12` for zero here.
 
 
-### Bulk TPM when single-cell is zero
+### Bulk counts when single-cell is zero
 
 
 ```{r fig.height=10, fig.width=12, message=FALSE, warning=FALSE}
@@ -424,7 +424,7 @@ ggplot(plot_df) +
 
 
 
-### Single-cell when bulk TPM is zero
+### Single-cell when bulk counts is zero
 
 
 ```{r fig.height=10, fig.width=12, message=FALSE, warning=FALSE}

--- a/analysis/pseudobulk-bulk-prediction/run-prediction.sh
+++ b/analysis/pseudobulk-bulk-prediction/run-prediction.sh
@@ -29,7 +29,7 @@ for project_dir in $scpca_dir/*; do
     project_id=$(basename $project_dir)
 
     tpm_file="${tpm_dir}/${project_id}-tpm.tsv"
-    pseudobulk_file="${pseudobulk_dir}/${project_id}-pseudobulk.rds"
+    pseudobulk_file="${pseudobulk_dir}/${project_id}-pseudobulk.tsv"
 
     # Step 1: Calculate bulk TPM for each project
     if [ ! -f ${tpm_file} ]; then
@@ -37,7 +37,7 @@ for project_dir in $scpca_dir/*; do
         --input_dir "${scpca_dir}/${project_id}" \
         --output_file "${tpm_file}"
     fi
-    
+
     # Step 2: Calculate pseudobulk matrices for each project
     if [ ! -f ${pseudobulk_file} ]; then
       Rscript ${script_dir}/calculate-pseudobulk.R \

--- a/analysis/pseudobulk-bulk-prediction/run-prediction.sh
+++ b/analysis/pseudobulk-bulk-prediction/run-prediction.sh
@@ -13,10 +13,12 @@ data_dir="data"
 script_dir="scripts"
 scpca_dir="${data_dir}/scpca_data"
 tpm_dir="${data_dir}/tpm"
+pseudobulk_dir="${data_dir}/pseudobulk"
 result_dir="results"
 
 mkdir -p $scpca_dir
 mkdir -p $tpm_dir
+mkdir -p $pseudobulk_dir
 mkdir -p $result_dir
 
 # Step 0: Sync data files from S3
@@ -27,9 +29,19 @@ for project_dir in $scpca_dir/*; do
     project_id=$(basename $project_dir)
 
     tpm_file="${tpm_dir}/${project_id}-tpm.tsv"
+    pseudobulk_file="${pseudobulk_dir}/${project_id}-pseudobulk.rds"
 
-    # Step 1: Calculate TPM for each project
-    Rscript ${script_dir}/calculate-tpm.R \
+    # Step 1: Calculate bulk TPM for each project
+    if [ ! -f ${tpm_file} ]; then
+      Rscript ${script_dir}/calculate-tpm.R \
         --input_dir "${scpca_dir}/${project_id}" \
         --output_file "${tpm_file}"
+    fi
+    
+    # Step 2: Calculate pseudobulk matrices for each project
+    if [ ! -f ${pseudobulk_file} ]; then
+      Rscript ${script_dir}/calculate-pseudobulk.R \
+        --input_dir "${scpca_dir}/${project_id}" \
+        --output_file "${pseudobulk_file}"
+    fi
 done

--- a/analysis/pseudobulk-bulk-prediction/run-prediction.sh
+++ b/analysis/pseudobulk-bulk-prediction/run-prediction.sh
@@ -23,7 +23,14 @@ mkdir -p $result_dir
 
 # Step 0: Sync data files from S3
 Rscript ${script_dir}/sync-data-files.R \
-  --output_dir ${scpca_dir}
+  --output_dir ${scpca_dir} \
+  --map_file ${scpca_dir}/bulk_library_sample_ids.tsv
+
+# Prepare bulk counts data for comparisons
+Rscript ${script_dir}/prepare-bulk-counts.R \
+  --input_dir ${scpca_dir} \
+  --map_file ${scpca_dir}/bulk_library_sample_ids.tsv \
+  --output_file ${scpca_dir}/normalized_bulk_counts.rds
 
 for project_dir in $scpca_dir/*; do
     project_id=$(basename $project_dir)

--- a/analysis/pseudobulk-bulk-prediction/scripts/README.md
+++ b/analysis/pseudobulk-bulk-prediction/scripts/README.md
@@ -3,6 +3,9 @@ This directory contains scripts used in the analysis to predict bulk expression 
 * `sync-data-files.R`: This script syncs data files for analysis.
   * It identifies solid tumor samples of interest libraries of interest and obtains their bulk `quant.sf` files and single-cell `_processed.rds` files from S3.
   Files are saved in `../data/scpca-data/<project id>/<sample id>/`.
+  * It also exports a TSV mapping library and sample ids for bulk that we are interested in, to `../data/scpca_data/bulk_library_sample_ids.tsv`
+* `prepare-bulk-counts.R`: This script creates an RDS file with a lists of data frames of all bulk counts, normalized by DESeq2.
+The RDS file is exported to `../data/scpca_data/normalized_bulk_counts.rds`
 * `calculate-tpm.R`: This script creates a TSV of TPM values for all samples in a given project.
 TSV files are exported to `../data/tpm/<project id>-tpm.tsv`.
 * `calculate-pseudobulk.R`: This script creates a TSV of pseudobulk values, using two different approaches, for all samples in a given project.

--- a/analysis/pseudobulk-bulk-prediction/scripts/README.md
+++ b/analysis/pseudobulk-bulk-prediction/scripts/README.md
@@ -5,3 +5,5 @@ This directory contains scripts used in the analysis to predict bulk expression 
   Files are saved in `../data/scpca-data/<project id>/<sample id>/`.
 * `calculate-tpm.R`: This script creates a TSV of TPM values for all samples in a given project.
 TSV files are exported to `../data/tpm/<project id>-tpm.tsv`.
+* `calculate-pseudobulk.R`: This script creates a TSV of pseudobulk values, using two different approaches, for all samples in a given project.
+TSV files are exported to `../data/pseudobulk/<project id>-pseudobulk.tsv`.

--- a/analysis/pseudobulk-bulk-prediction/scripts/calculate-pseudobulk.R
+++ b/analysis/pseudobulk-bulk-prediction/scripts/calculate-pseudobulk.R
@@ -92,7 +92,7 @@ make_long <- function(pseudo_mat, label) {
 
 pseudo_df <- dplyr::bind_rows(
   make_long(pseudo_deseq, "pseudobulk_deseq"), 
-  make_long(pseudo_deseq, "pseudobulk_log_counts")
+  make_long(pseudo_log_counts, "pseudobulk_log_counts")
 )
 
 # Export ------------------

--- a/analysis/pseudobulk-bulk-prediction/scripts/calculate-pseudobulk.R
+++ b/analysis/pseudobulk-bulk-prediction/scripts/calculate-pseudobulk.R
@@ -71,9 +71,8 @@ pseudo_deseq <- DESeqDataSetFromMatrix(
   assay() 
 
 
-# Approach 2: Sum counts and log2 directly ----------------
+# Approach 2: Sum counts and log1p (but base 2) directly ----------------
 pseudo_log_counts <- log1p(pseudo_raw_counts)/log(2)
-
 
 # Combine into a single long data frame ---------------------
 

--- a/analysis/pseudobulk-bulk-prediction/scripts/calculate-pseudobulk.R
+++ b/analysis/pseudobulk-bulk-prediction/scripts/calculate-pseudobulk.R
@@ -99,6 +99,12 @@ colnames(pseudo_logcounts) <- sample_ids
 
 
 # Export ------------------
+
+# Confirm we have the same genes
+stopifnot(
+  setequal(rownames(pseudo_deseq), rownames(pseudo_logcounts))
+)
+
 pseudo_list <- list(
   pseudobulk_deseq = pseudo_deseq, 
   pseudobulk_logcounts = pseudo_logcounts

--- a/analysis/pseudobulk-bulk-prediction/scripts/calculate-pseudobulk.R
+++ b/analysis/pseudobulk-bulk-prediction/scripts/calculate-pseudobulk.R
@@ -45,7 +45,7 @@ fs::dir_create(dirname(opts$output_file))
 # Read in all SCEs----------------
 rds_files <- list.files(
   path = opts$input_dir,
-  pattern = "*_processed.rds",
+  pattern = "_processed\\.rds$",
   recursive = TRUE
 )
 stopifnot(
@@ -59,10 +59,10 @@ names(rds_files) <- sample_ids
 sce_list <- purrr::map(rds_files, readr::read_rds)
 
 pseudo_raw_counts <- sce_list |>
-  counts() |>
-  purrr::map(DelayedArray::rowSums) |>
+  purrr::map(counts) |>
+  purrr::map(rowSums) |>
   # cbind seems to make the names go away, which is sad
-  purrr::reduce(cbind)
+ do.call(cbind, args = _ )
 
 colnames(pseudo_raw_counts) <- sample_ids
 

--- a/analysis/pseudobulk-bulk-prediction/scripts/calculate-pseudobulk.R
+++ b/analysis/pseudobulk-bulk-prediction/scripts/calculate-pseudobulk.R
@@ -61,7 +61,7 @@ sce_list <- purrr::map(rds_files, readr::read_rds)
 pseudo_raw_counts <- sce_list |>
   counts() |>
   purrr::map(DelayedArray::rowSums) |>
-  # reduce seems to make the names go away, which is sad
+  # cbind seems to make the names go away, which is sad
   purrr::reduce(cbind)
 
 colnames(pseudo_raw_counts) <- sample_ids

--- a/analysis/pseudobulk-bulk-prediction/scripts/calculate-pseudobulk.R
+++ b/analysis/pseudobulk-bulk-prediction/scripts/calculate-pseudobulk.R
@@ -72,7 +72,7 @@ pseudo_deseq <- DESeqDataSetFromMatrix(
 
 
 # Approach 2: Sum counts and log2 directly ----------------
-pseudo_log_counts <- log2(pseudo_raw_counts)
+pseudo_log_counts <- log1p(pseudo_raw_counts)/log(2)
 
 
 # Combine into a single long data frame ---------------------

--- a/analysis/pseudobulk-bulk-prediction/scripts/calculate-pseudobulk.R
+++ b/analysis/pseudobulk-bulk-prediction/scripts/calculate-pseudobulk.R
@@ -1,0 +1,106 @@
+# This script calculates two flavors of pseudobulk normalized counts for a given project.
+# The script exports an RDS file with a list of two matrices:
+#  1. `pseudobulk_deseq`: Pseudobulk calculated by summing raw counts and normalizing them with DESeq2
+#  2. `pseudobulk_logcounts`: Pseudobulk calculated by summing logcounts directly
+#
+# Currently, we also discard genes for which 
+
+renv::load()
+suppressPackageStartupMessages({
+  library(optparse)
+  library(DESeq2)
+  library(SingleCellExperiment)
+})
+
+
+# Parse options --------
+option_list <- list(
+  make_option(
+    "--input_dir",
+    type = "character",
+    help = "Input directory containing all _processed.rds files, which will be found recursively"
+  ),
+  make_option(
+    "--output_file",
+    type = "character",
+    help = "Path to output RDS to save pseudobulk matrices"
+  ), 
+  make_option(
+    "--min_count_per_gene",
+    type = "integer",
+    default = 10, # TODO: Do we just to get rid of rows that are all 0s, and remove this option entirely?
+    help = "Threshold raw expression level to retain genes. If the pseudobulk count is less than this value, we discard the gene."
+  )
+)
+opts <- parse_args(OptionParser(option_list = option_list))
+
+# Check inputs and paths -------
+stopifnot(
+  "An input directory must be provided to `input_dir`." = !is.null(opts$input_dir),
+  "A path to an output file must be specified with `output_file`." = !is.null(opts$output_file)
+)
+fs::dir_create(dirname(opts$output_file))
+
+
+# Read in all SCEs----------------
+rds_files <- list.files(
+  path = opts$input_dir,
+  pattern = "*_processed.rds",
+  recursive = TRUE
+) 
+stopifnot(
+  "Could not find any _processed.rds files in the provided `input_dir`." = length(rds_files) > 0
+)
+
+sample_ids <- stringr::str_split_i(rds_files, pattern = "/", i = 1)
+rds_files <- file.path(opts$input_dir, rds_files) # update to contain full path
+names(rds_files) <- sample_ids
+
+sce_list <- purrr::map(rds_files, readr::read_rds)
+
+pseudo_raw_counts <- sce_list |>
+  purrr::map(
+    \(sce) {
+      DelayedArray::rowSums(counts(sce)) 
+    }
+  ) |> 
+  # this seems to make the names go away, which is sad
+  purrr::reduce(cbind) 
+
+colnames(pseudo_raw_counts) <- sample_ids
+
+# We'll also identify rows to keep: at least opts$min_count_per_gene
+keep_rows <- DelayedArray::rowSums(pseudo_raw_counts >= opts$min_count_per_gene) > 0
+pseudo_raw_counts <- pseudo_raw_counts[keep_rows, ]
+
+
+# Approach 1: Normalize with DESeq 2 ----------------
+pseudo_deseq <- DESeqDataSetFromMatrix(
+  countData = pseudo_raw_counts, 
+  # these arguments don't matter for our purposes, 
+  # but DESeq2 requires them
+  colData = data.frame(sample = sample_ids), 
+  design = ~sample) |>
+  estimateSizeFactors() |>
+  rlog(blind = TRUE) |>
+  assay()
+
+
+# Approach 2: Sum logcounts directly ----------------
+pseudo_logcounts <- sce_list |>
+  purrr::map(
+    \(sce) {
+      # subset to the `keep_rows` we previously identified from the raw counts
+      DelayedArray::rowSums(logcounts(sce)[keep_rows, ]) 
+    }
+  ) |> 
+  purrr::reduce(cbind) 
+colnames(pseudo_logcounts) <- sample_ids
+
+
+# Export ------------------
+pseudo_list <- list(
+  pseudobulk_deseq = pseudo_deseq, 
+  pseudobulk_logcounts = pseudo_logcounts
+)
+readr::write_rds(pseudo_list, opts$output_file)

--- a/analysis/pseudobulk-bulk-prediction/scripts/calculate-tpm.R
+++ b/analysis/pseudobulk-bulk-prediction/scripts/calculate-tpm.R
@@ -62,7 +62,15 @@ txi_salmon <- tximport::tximport(
 )
 tpm_df  <- txi_salmon$abundance |>
   as.data.frame() |>
-  tibble::rownames_to_column("ensembl_id")
+  tibble::rownames_to_column("ensembl_id") |>
+  # make it long
+  tidyr::pivot_longer(
+    -ensembl_id, 
+    names_to = "sample_id", 
+    values_to = "expression"
+  ) |>
+  # add indicator column for the type of expression this file contains
+  dplyr::mutate(expression_type = "bulk_tpm")   
 
 
 # Export to tsv -------

--- a/analysis/pseudobulk-bulk-prediction/scripts/prepare-bulk-counts.R
+++ b/analysis/pseudobulk-bulk-prediction/scripts/prepare-bulk-counts.R
@@ -1,0 +1,90 @@
+# This script processes bulk counts expression into a list of data frames which can be used for analysis
+# This will include some of the multiplexed samples, but these will be filtered out in next steps
+
+renv::load()
+library(optparse)
+library(DESeq2)
+
+
+# Parse options --------
+option_list <- list(
+  make_option(
+    "--input_dir",
+    type = "character",
+    help = "Input directory containing all bulk TSV files, which will be found recursively"
+  ),
+  make_option(
+    "--map_file",
+    type = "character",
+    help = "Path to TSV file mapping bulk sample and library ids"
+  ),
+  make_option(
+    "--output_file",
+    type = "character",
+    help = "Path to output RDS containing normalized counts"
+  )
+)
+opts <- parse_args(OptionParser(option_list = option_list))
+
+
+# Checks ------------------
+stopifnot("Map file not found." = file.exists(opts$map_file))
+
+
+# Find and read in bulk files --------
+bulk_count_files <- list.files(
+  path = here::here("analysis", "pseudobulk-bulk-prediction", "data", "scpca_data"), 
+  full.names = TRUE,
+  pattern = "_bulk_quant\\.tsv$", 
+  recursive = TRUE
+) 
+stopifnot("No bulk count TSVs found" = length(bulk_count_files) > 0)
+bulk_count_names <- stringr::str_split_i(basename(bulk_count_files), pattern = "_", i = 1)
+names(bulk_count_files) <- bulk_count_names
+
+
+# Read map to swap library to sample ids --------
+sample_library_map <- readr::read_tsv(opts$map_file) |>
+  dplyr::rename(
+    sample_id = scpca_sample_id, 
+    library_id = scpca_library_id
+  )
+
+# Make a list of data frames of bulk counts, normalized by DESeq2
+bulk_counts_wide_df_list <- bulk_count_files |>
+  purrr::map(
+    \(counts_file) {
+      
+      df <- readr::read_tsv(counts_file, show_col_types = FALSE) 
+      counts_mat <- as.matrix(df |> dplyr::select(-gene_id))
+      rownames(counts_mat) <- df$gene_id
+      counts_mat <- round(counts_mat) # deal with non-integers which DESeq2 will require
+    
+      bulk_counts_mat <- DESeqDataSetFromMatrix(
+        countData = counts_mat,
+        # these arguments don't matter for our purposes,
+        # but DESeq2 requires them
+        colData = data.frame(sample = colnames(counts_mat)),
+        design = ~sample) |>
+        estimateSizeFactors() |>
+        rlog(blind = TRUE) |>
+        assay() 
+      
+      bulk_counts_mat |>
+        as.data.frame() |>
+        tibble::rownames_to_column(var = "gene_id") |>
+        tidyr::pivot_longer(
+          -gene_id, 
+          names_to = "library_id", # library! 
+          values_to = "bulk_counts"
+        ) |>
+        # swap to sample name
+        dplyr::left_join(sample_library_map) |>
+        dplyr::select(gene_id, sample_id, bulk_counts) |>
+        tidyr::drop_na()
+        
+    }
+  )
+
+# Save to RDS ----------
+readr::write_rds(bulk_counts_wide_df_list, opts$output_file)

--- a/renv.lock
+++ b/renv.lock
@@ -182,6 +182,30 @@
       ],
       "Hash": "0308920b8b9315ccfe69bccb66c15485"
     },
+    "DESeq2": {
+      "Package": "DESeq2",
+      "Version": "1.44.0",
+      "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
+      "Requirements": [
+        "Biobase",
+        "BiocGenerics",
+        "BiocParallel",
+        "GenomicRanges",
+        "IRanges",
+        "MatrixGenerics",
+        "Rcpp",
+        "RcppArmadillo",
+        "S4Vectors",
+        "SummarizedExperiment",
+        "ggplot2",
+        "locfit",
+        "matrixStats",
+        "methods",
+        "stats4"
+      ],
+      "Hash": "a90e0e67215ba95ccb29e93b169caaa4"
+    },
     "DelayedArray": {
       "Package": "DelayedArray",
       "Version": "0.30.1",
@@ -559,6 +583,20 @@
         "methods"
       ],
       "Hash": "f6baa1e06fb6c3724f601a764266cb0d"
+    },
+    "RcppArmadillo": {
+      "Package": "RcppArmadillo",
+      "Version": "14.2.2-1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "Rcpp",
+        "methods",
+        "stats",
+        "utils"
+      ],
+      "Hash": "9da7c242d94a8419d045f6b3a64b9765"
     },
     "RcppEigen": {
       "Package": "RcppEigen",


### PR DESCRIPTION
Closes #128 

This PR adds a new script to calculate pseudobulk, and a notebook to compare the values to TPM. While there is no horn in this data, there sure is a pretty clean relationship all things considered!

See notebook: [pseudobulk-calculations.nb.html.zip](https://github.com/user-attachments/files/18594135/pseudobulk-calculations.nb.html.zip)

#### The script

- Here, I use two strategies to convert:
  - sum the logcounts
  - sum the raw counts and let deseq2 normalize (note there are `renv.lock` changes because of this)
- As part of this, I also included a threshold for dropping genes that have too many zeros - feedback here appreciated!

#### The notebook

- I'm aware there's a bit of a wrangling 🎢 at the top and wanted to note that part of this is to be able to get the data needed for the TPM density plots showing genes included in/excluded from pseudobulk.
  - Speaking of which, I end up converting to from wide -> long format pretty early in the notebook. After the fact, I felt I should probably go back and update the scripts to do this in the first place since we'll need long format to model also. Do you think that there's a good reason to keep the underlying data in a wide format, or should I go ahead and update the scripts to make it all long in the first place?
- The two strategies for pseudobulking are highly similar, and neither seems bad either. With only minimal empirical justification, I conclude we should probably use the deseq2 version, but the good news is it doesn't appear this choice will matter _too_ much.
- During discussion, it was mentioned that we should make sure to show gene lengths in these plots somehow. I haven't done this yet, for 2 reasons:
  - the relationships seemed clean and unbiased in the first place
  - by the time I was going to add this in, the code seemed like quite enough review for one PR. But let me know if you want me to add it now, or in a followup PR (or neither?)?



