### PR TITLE
Export tables of gene expression percentage across samples

### DIFF
--- a/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/compare-pseudobulk-bulk.Rmd
+++ b/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/compare-pseudobulk-bulk.Rmd
@@ -38,7 +38,7 @@ theme_set(theme_bw())
 data_dir <- here::here("analysis", "pseudobulk-bulk-prediction", "data")
 tpm_dir <- file.path(data_dir, "tpm")
 pseudobulk_dir <- file.path(data_dir, "pseudobulk")
-bulk_counts_file <- file.path(data_dir, "scpca_data", "normalized_bulk_counts.rds")
+bulk_counts_file <- file.path(data_dir, "normalized-bulk-counts.rds")
 
 tpm_files <- list.files(
   path = tpm_dir,
@@ -111,8 +111,7 @@ bulk_df_list <- readr::read_rds(bulk_counts_file) |>
   purrr::map(
     \(df) {
       df |>
-        dplyr::filter(sample_id %in% present_samples) |>
-        dplyr::rename(ensembl_id = gene_id)
+        dplyr::filter(sample_id %in% present_samples) 
     }
   )
 

--- a/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/compare-pseudobulk-bulk.Rmd
+++ b/analysis/pseudobulk-bulk-prediction/exploratory-notebooks/compare-pseudobulk-bulk.Rmd
@@ -43,18 +43,18 @@ bulk_counts_file <- file.path(data_dir, "normalized-bulk-counts.rds")
 tpm_files <- list.files(
   path = tpm_dir,
   full.names = TRUE,
-  pattern = "-tpm\\.tsv$"
+  pattern = "_tpm\\.tsv$"
 )
-tpm_names <- stringr::str_split_i(basename(tpm_files), pattern = "-", i = 1)
+tpm_names <- stringr::str_split_i(basename(tpm_files), pattern = "_", i = 1)
 names(tpm_files) <- tpm_names
 
 
 pseudobulk_files <- list.files(
   path = pseudobulk_dir,
   full.names = TRUE,
-  pattern = "-pseudobulk\\.tsv$"
+  pattern = "_pseudobulk\\.tsv$"
 )
-pseudobulk_names <- stringr::str_split_i(basename(pseudobulk_files), pattern = "-", i = 1)
+pseudobulk_names <- stringr::str_split_i(basename(pseudobulk_files), pattern = "_", i = 1)
 names(pseudobulk_files) <- pseudobulk_names
 
 # Make sure we have the same projects, in the same order

--- a/analysis/pseudobulk-bulk-prediction/run-prediction.sh
+++ b/analysis/pseudobulk-bulk-prediction/run-prediction.sh
@@ -40,12 +40,12 @@ Rscript ${script_dir}/prepare-bulk-counts.R \
 for project_dir in $scpca_dir/*; do
     project_id=$(basename $project_dir)
 
-    pseudobulk_file="${pseudobulk_dir}/${project_id}-pseudobulk.tsv"
-    percent_expressed_file="${data_dir}/percent-expressed-single-cell.tsv"
+    pseudobulk_file="${pseudobulk_dir}/${project_id}_pseudobulk.tsv"
+    percent_expressed_file="${data_dir}/${project_id}_percent-expressed-single-cell.tsv"
 
     ###### TPMs are not currently used in the analysis ######
     # Calculate bulk TPM for each project
-    #tpm_file="${tpm_dir}/${project_id}-tpm.tsv"
+    #tpm_file="${tpm_dir}/${project_id}_tpm.tsv"
     #Rscript ${script_dir}/calculate-tpm.R \
     #  --input_dir "${scpca_dir}/${project_id}" \
     #  --output_pseudobulk_file "${tpm_file}"

--- a/analysis/pseudobulk-bulk-prediction/run-prediction.sh
+++ b/analysis/pseudobulk-bulk-prediction/run-prediction.sh
@@ -35,13 +35,13 @@ Rscript ${script_dir}/prepare-bulk-counts.R \
   --input_dir "${scpca_dir}" \
   --map_file "${map_file}" \
   --output_counts_file "${data_dir}/normalized-bulk-counts.rds" \
-  --output_percent_expressed_file "${data_dir}/percent-expressed-bulk.tsv"
+  --output_frac_expressed_file "${data_dir}/fraction-expressed-bulk.tsv"
 
 for project_dir in $scpca_dir/*; do
     project_id=$(basename $project_dir)
 
     pseudobulk_file="${pseudobulk_dir}/${project_id}_pseudobulk.tsv"
-    percent_expressed_file="${data_dir}/${project_id}_percent-expressed-single-cell.tsv"
+    fraction_expressed_file="${data_dir}/${project_id}_fraction-expressed-single-cell.tsv"
 
     ###### TPMs are not currently used in the analysis ######
     # Calculate bulk TPM for each project
@@ -54,7 +54,7 @@ for project_dir in $scpca_dir/*; do
     Rscript ${script_dir}/calculate-pseudobulk.R \
       --input_dir "${scpca_dir}/${project_id}" \
       --output_pseudobulk_file "${pseudobulk_file}" \
-      --output_percent_expressed_file "${percent_expressed_file}"
+      --output_frac_expressed_file "${fraction_expressed_file}"
 done
 
 # Build and export models to results/models/

--- a/analysis/pseudobulk-bulk-prediction/scripts/calculate-pseudobulk.R
+++ b/analysis/pseudobulk-bulk-prediction/scripts/calculate-pseudobulk.R
@@ -3,7 +3,7 @@
 #  1. `pseudobulk_deseq`: Pseudobulk calculated by summing raw counts and normalizing them with DESeq2
 #  2. `pseudobulk_log_counts`: Pseudobulk calculated by summing counts and taking their log2
 #
-# Currently, we also discard genes for which
+# The script also exports a TSV of the percent of samples each gene is expressed in
 
 renv::load()
 suppressPackageStartupMessages({
@@ -21,9 +21,14 @@ option_list <- list(
     help = "Input directory containing all _processed.rds files, which will be found recursively"
   ),
   make_option(
-    "--output_file",
+    "--output_pseudobulk_file",
     type = "character",
     help = "Path to output TSV to save pseudobulk calculations"
+  ),
+  make_option(
+    "--output_percent_expressed_file",
+    type = "character",
+    help = "Path to output TSV to save percent of samples each gene is expressed in, based on raw counts"
   )
 )
 opts <- parse_args(OptionParser(option_list = option_list))
@@ -31,9 +36,11 @@ opts <- parse_args(OptionParser(option_list = option_list))
 # Check inputs and paths -------
 stopifnot(
   "An input directory must be provided to `input_dir`." = !is.null(opts$input_dir),
-  "A path to an output file must be specified with `output_file`." = !is.null(opts$output_file)
+  "A path to an output TSV file to save pseudobulk counts must be specified with `output_pseudoulk_file`." = !is.null(opts$output_pseudobulk_file),
+  "A path to an output TSV file to save percent of single-cell samples genes are expressed in must be specified with `output_percent_expressed_file`." = !is.null(opts$output_percent_expressed_file)
 )
-fs::dir_create(dirname(opts$output_file))
+fs::dir_create(dirname(opts$output_pseudobulk_file))
+fs::dir_create(dirname(opts$output_percent_expressed_file))
 
 
 # Read in all SCEs----------------
@@ -57,6 +64,13 @@ pseudo_raw_counts <- sce_list |>
   purrr::map(counts) |>
   purrr::map(rowSums) |>
   do.call(cbind, args = _ )
+
+
+# Export table of percent expressed based on raw counts alone
+rowMeans(pseudo_raw_counts > 0) |>
+  tibble::as_tibble(rownames = "ensembl_id") |>
+  dplyr::rename(percent_samples_expressed = value) |>
+  readr::write_tsv(opts$output_percent_expressed_file)
 
 
 # Approach 1: Normalize with DESeq 2 ----------------
@@ -95,4 +109,4 @@ pseudo_df <- dplyr::bind_rows(
 )
 
 # Export ------------------
-readr::write_tsv(pseudo_df, opts$output_file)
+readr::write_tsv(pseudo_df, opts$output_pseudobulk_file)

--- a/analysis/pseudobulk-bulk-prediction/scripts/prepare-bulk-counts.R
+++ b/analysis/pseudobulk-bulk-prediction/scripts/prepare-bulk-counts.R
@@ -116,4 +116,4 @@ readr::write_rds(bulk_dat[[1]], opts$output_counts_file)
 # Save percent expressed to TSV
 bulk_dat[[2]] |> 
   purrr::list_rbind(names_to = "project_id") |>
-  readr::write_rds(opts$output_percent_expressed_file)
+  readr::write_tsv(opts$output_percent_expressed_file)

--- a/analysis/pseudobulk-bulk-prediction/scripts/prepare-bulk-counts.R
+++ b/analysis/pseudobulk-bulk-prediction/scripts/prepare-bulk-counts.R
@@ -24,9 +24,9 @@ option_list <- list(
     help = "Path to output RDS containing normalized counts"
   ),
   make_option(
-    "--output_percent_expressed_file",
+    "--output_frac_expressed_file",
     type = "character",
-    help = "Path to output TSV to save, per project, the percent of samples each gene is expressed in, based on raw counts"
+    help = "Path to output TSV to save, per project, the fraction of samples each gene is expressed in, based on raw counts"
   )
 )
 opts <- parse_args(OptionParser(option_list = option_list))
@@ -37,19 +37,19 @@ stopifnot(
   "An input directory must be provided to `input_dir`." = !is.null(opts$input_dir),
   "Map file not found." = file.exists(opts$map_file),
   "A path to an output TSV file to save counts must be specified with `output_counts_file`." = !is.null(opts$output_counts_file),
-  "A path to an output TSV file to save percent per project of single-cell samples genes are expressed in must be specified with `output_percent_expressed_file`." = !is.null(opts$output_percent_expressed_file)
+  "A path to an output TSV file to save fraction per project of single-cell samples genes are expressed in must be specified with `output_frac_expressed_file`." = !is.null(opts$output_frac_expressed_file)
 )
 fs::dir_create(dirname(opts$output_counts_file))
-fs::dir_create(dirname(opts$output_percent_expressed_file))
+fs::dir_create(dirname(opts$output_frac_expressed_file))
 
 
 # Find and read in bulk files --------
 bulk_count_files <- list.files(
-  path = opts$input_dir, 
+  path = opts$input_dir,
   full.names = TRUE,
-  pattern = "_bulk_quant\\.tsv$", 
+  pattern = "_bulk_quant\\.tsv$",
   recursive = TRUE
-) 
+)
 stopifnot("No bulk count TSVs found" = length(bulk_count_files) > 0)
 bulk_count_names <- stringr::str_split_i(basename(bulk_count_files), pattern = "_", i = 1)
 names(bulk_count_files) <- bulk_count_names
@@ -58,7 +58,7 @@ names(bulk_count_files) <- bulk_count_names
 # Read map to swap library to sample ids --------
 sample_library_map <- readr::read_tsv(opts$map_file) |>
   dplyr::rename(
-    sample_id = scpca_sample_id, 
+    sample_id = scpca_sample_id,
     library_id = scpca_library_id
   )
 
@@ -66,12 +66,12 @@ sample_library_map <- readr::read_tsv(opts$map_file) |>
  bulk_dat <- bulk_count_files |>
   purrr::map(
     \(counts_file) {
-      
-      df <- readr::read_tsv(counts_file, show_col_types = FALSE) 
+
+      df <- readr::read_tsv(counts_file, show_col_types = FALSE)
       counts_mat <- as.matrix(df |> dplyr::select(-gene_id))
       rownames(counts_mat) <- df$gene_id
       counts_mat <- round(counts_mat) # deal with non-integers which DESeq2 will require
-    
+
       bulk_counts_mat <- DESeqDataSetFromMatrix(
         countData = counts_mat,
         # these arguments don't matter for our purposes,
@@ -80,40 +80,40 @@ sample_library_map <- readr::read_tsv(opts$map_file) |>
         design = ~sample) |>
         estimateSizeFactors() |>
         rlog(blind = TRUE) |>
-        assay() 
-      
-      # data frame of bulk counts 
+        assay()
+
+      # data frame of bulk counts
       bulk_counts_df <- bulk_counts_mat |>
         as.data.frame() |>
         tibble::rownames_to_column(var = "ensembl_id") |>
         tidyr::pivot_longer(
-          -ensembl_id, 
-          names_to = "library_id", # library! 
+          -ensembl_id,
+          names_to = "library_id", # library!
           values_to = "bulk_counts"
         ) |>
         # swap to sample name
         dplyr::left_join(sample_library_map) |>
         dplyr::select(ensembl_id, sample_id, bulk_counts) |>
         tidyr::drop_na()
-      
-      # data frame of percent of samples genes are expressed in
-      percent_expr_df <- rowMeans(counts_mat > 0) |>
+
+      # data frame of fraction of samples genes are expressed in
+      frac_expr_df <- rowMeans(counts_mat > 0) |>
         tibble::as_tibble(rownames = "ensembl_id") |>
-        dplyr::rename(percent_samples_expressed = value) 
-      
+        dplyr::rename(frac_samples_expressed = value)
+
       return(
-        list(bulk_counts_df,  percent_expr_df)
+        list(bulk_counts_df, frac_expr_df)
       )
     }
-  ) |> 
+  ) |>
    purrr::transpose()
 
 # Export -----------
- 
+
 # Save counts to RDS
 readr::write_rds(bulk_dat[[1]], opts$output_counts_file)
 
-# Save percent expressed to TSV
-bulk_dat[[2]] |> 
+# Save fraction expressed to TSV
+bulk_dat[[2]] |>
   purrr::list_rbind(names_to = "project_id") |>
-  readr::write_tsv(opts$output_percent_expressed_file)
+  readr::write_tsv(opts$output_frac_expressed_file)

--- a/analysis/pseudobulk-bulk-prediction/scripts/sync-data-files.R
+++ b/analysis/pseudobulk-bulk-prediction/scripts/sync-data-files.R
@@ -18,6 +18,11 @@ option_list <- list(
     help = "Output directory to save synced data files organized by project/sample"
   ),
   make_option(
+    "--map_file",
+    type = "character",
+    help = "Path to output TSV file mapping bulk sample and library ids",
+  ),
+  make_option(
     "--sample_metadata_file",
     type = "character",
     default = here::here("s3_files", "scpca-sample-metadata.tsv"),
@@ -39,9 +44,6 @@ stopifnot(
 )
 s3_bulk_tpm_path <- "s3://nextflow-ccdl-results/scpca-prod/checkpoints/salmon" #/library_id/quant.sf
 s3_processed_path <- "s3://nextflow-ccdl-results/scpca-prod/results" #/project_id/sample_id/library_id_processed.rds AND project_id/bulk/<project_id>_bulk_quant.tsv
-
-ids_file <- file.path(opts$output_dir, "bulk_library_sample_ids.tsv")
-
 
 fs::dir_create(opts$output_dir)
 
@@ -179,4 +181,4 @@ bulk_libraries_samples <- library_metadata |>
     seq_unit == "bulk"
   ) |>
   dplyr::select(scpca_sample_id, scpca_library_id)
-readr::write_tsv(bulk_libraries_samples, ids_file)
+readr::write_tsv(bulk_libraries_samples, opts$map_file)


### PR DESCRIPTION
Towards #144 

This PR updates data preparation scripts to also export tables with the percent of samples each gene is expressed in. These can be used for later filtering. Currently I am exporting these to `data`, but we could send them to `results` instead.

While I was here, I caught a few tiny bugs or mediocre code approaches (e.g. a hardcoded file path that should be an argument!) and made updates accordingly. In particular, I had added various files over time to `data/scpca_data` which somewhat broke the `run_prediction.sh` script for look over projects in that directory. I therefore decided to move files were are not literally ScPCA out of that directory and into its parent `data`. 

I also made a couple file names a bit more consistent with underscores/dashes. Because of these small filename changes, I also updated paths/file parsing in the exploratory notebook accordingly.
