### PR TITLE
Establish ESTIMATE analysis directory

### DIFF
--- a/analysis/estimate/.gitignore
+++ b/analysis/estimate/.gitignore
@@ -1,0 +1,4 @@
+# Ignore the data directory (but keep it present)
+/data/*
+!/data/.gitkeep
+

--- a/analysis/estimate/README.md
+++ b/analysis/estimate/README.md
@@ -1,0 +1,12 @@
+This directory contains scripts and results for analyzing bulk and pseudobulk RNASeq samples with `ESTIMATE` ([Yoshihara et al, 2013](https://doi.org/10.1038/ncomms3612)).
+
+To run the analysis, run:
+
+```sh
+bash run-estimate-analysis.sh
+```
+
+If you use 1Password to manage your credentials, you may need to run:
+```sh
+op run -- bash run-estimate-analysis.sh
+```

--- a/analysis/estimate/run-estimate-analysis.sh
+++ b/analysis/estimate/run-estimate-analysis.sh
@@ -19,11 +19,9 @@ mkdir -p $scpca_dir
 mkdir -p $tpm_dir
 mkdir -p $pseudobulk_dir
 
-library_sample_map_file="${data_dir}/bulk-library-sample-ids.tsv"
 ensembl_symbol_map_file="${data_dir}/ensembl-symbol-map.tsv"
 
 # Sync data files from S3
 Rscript ${script_dir}/sync-data-files.R \
   --output_dir "${scpca_dir}" \
-  --library_sample_map_file "${library_sample_map_file}" \
   --ensembl_symbol_map_file "${ensembl_symbol_map_file}"

--- a/analysis/estimate/run-estimate-analysis.sh
+++ b/analysis/estimate/run-estimate-analysis.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# This script runs an analysis using ESTIMATE
+
+set -euo pipefail
+
+# Run script from its location
+basedir=$(dirname "${BASH_SOURCE[0]}")
+cd "$basedir"
+
+# Define directories
+data_dir="data"
+script_dir="scripts"
+scpca_dir="${data_dir}/scpca"
+tpm_dir="${data_dir}/tpm"
+pseudobulk_dir="${data_dir}/pseudobulk"
+
+mkdir -p $scpca_dir
+mkdir -p $tpm_dir
+mkdir -p $pseudobulk_dir
+
+library_sample_map_file="${data_dir}/bulk-library-sample-ids.tsv"
+ensembl_symbol_map_file="${data_dir}/ensembl-symbol-map.tsv"
+
+# Sync data files from S3
+Rscript ${script_dir}/sync-data-files.R \
+  --output_dir "${scpca_dir}" \
+  --library_sample_map_file "${library_sample_map_file}" \
+  --ensembl_symbol_map_file "${ensembl_symbol_map_file}"

--- a/analysis/estimate/scripts/README.md
+++ b/analysis/estimate/scripts/README.md
@@ -1,0 +1,8 @@
+This directory contains scripts used in the analysis to predict bulk expression from matched pseudobulk expression.
+
+* `sync-data-files.R`: This script syncs data files for analysis.
+  * It identifies solid tumor samples of interest libraries of interest and obtains their bulk `quant.sf` files and single-cell `_processed.rds` files from S3.
+  Files are saved in `../data/scpca/<project id>/<sample id>/`.
+  * It also exports two TSVs to `../data`:
+    * Map for bulk library and sample ids
+    * Map for ensembl ids and gene symbols

--- a/analysis/estimate/scripts/README.md
+++ b/analysis/estimate/scripts/README.md
@@ -1,8 +1,6 @@
 This directory contains scripts used in the analysis to predict bulk expression from matched pseudobulk expression.
 
 * `sync-data-files.R`: This script syncs data files for analysis.
-  * It identifies solid tumor samples of interest libraries of interest and obtains their bulk `quant.sf` files and single-cell `_processed.rds` files from S3.
+  * It identifies solid tumor libraries of interest and obtains their bulk `quant.sf` files and single-cell `_processed.rds` files from S3.
   Files are saved in `../data/scpca/<project id>/<sample id>/`.
-  * It also exports two TSVs to `../data`:
-    * Map for bulk library and sample ids
-    * Map for ensembl ids and gene symbols
+  * It also exports a TSV to `../data` that maps ensembl ids to gene symbols

--- a/analysis/estimate/scripts/sync-data-files.R
+++ b/analysis/estimate/scripts/sync-data-files.R
@@ -1,0 +1,203 @@
+# This script prepares files needed for analysis:
+# 1. First, we identify samples of interest as non-multiplexed samples from solid tumors with paired bulk data
+# 2. Second, we sync all associated bulk `quant.sf` files and single-cell `_processed.rds` files from S3 needed for analysis
+# 3. Third, we sync all associated bulk counts from `_bulk_quant.tsv` from S3
+# All files are organized in `<project id>/<sample id>/` (except bulk counts which are only per project)
+# We also export two TSV file mapping files:
+# 1. A TSV mapping bulk library and sample ids, since the raw bulk counts use library id identifiers
+# 2. A TSV mapping gene symbols to ensembl ids, since ESTIMATE uses gene symbols
+
+
+renv::load()
+library(optparse)
+
+
+# Parse options --------
+option_list <- list(
+  make_option(
+    "--output_dir",
+    type = "character",
+    help = "Output directory to save synced data files organized by project/sample"
+  ),
+  make_option(
+    "--scpca_sce_file",
+    type = "character",
+    default = here::here("s3_files", "SCPCS000001", "SCPCL000001_processed.rds"),
+    help = "Path to an SCE file used to obtain mappings for converting ensembl ids to gene symbols"
+  ),
+  make_option(
+    "--library_sample_map_file",
+    type = "character",
+    help = "Path to output TSV file mapping bulk sample and library ids",
+  ),
+  make_option(
+    "--ensembl_symbol_map_file",
+    type = "character",
+    help = "Path to output TSV file mapping ensembl ids and gene symbols",
+  ),
+  make_option(
+    "--sample_metadata_file",
+    type = "character",
+    default = here::here("s3_files", "scpca-sample-metadata.tsv"),
+    help = "Path to ScPCA sample metadata file."
+  ),
+  make_option(
+    "--library_metadata_file",
+    type = "character",
+    default = here::here("s3_files", "scpca-library-metadata.tsv"),
+    help = "Path to ScPCA library metadata file."
+  )
+)
+opts <- parse_args(OptionParser(option_list = option_list))
+
+# Define files and directories ---------
+
+stopifnot(
+  "Metadata files could not be found. Were they synced?" = all(file.exists(c(opts$library_metadata_file, opts$sample_metadata_file))),
+  "The SCE file to use for id mapping could not be found. Was it synced?" = file.exists(opts$scpca_sce_file)
+)
+s3_bulk_tpm_path <- "s3://nextflow-ccdl-results/scpca-prod/checkpoints/salmon" #/library_id/quant.sf
+s3_processed_path <- "s3://nextflow-ccdl-results/scpca-prod/results" #/project_id/sample_id/library_id_processed.rds AND project_id/bulk/<project_id>_bulk_quant.tsv
+
+fs::dir_create(opts$output_dir)
+
+## Determine samples of interest -----------
+
+library_metadata <- readr::read_tsv(opts$library_metadata_file, show_col_types = FALSE)
+sample_metadata <- readr::read_tsv(opts$sample_metadata_file, show_col_types = FALSE)
+
+# we can't include multiplexed in this analysis, so we'll find those for removal
+cellhash_samples <- library_metadata |>
+  dplyr::filter(stringr::str_detect(technology, "cellhash")) |>
+  dplyr::pull(scpca_sample_id) |>
+  stringr::str_split(pattern = ";") |>
+  purrr::reduce(union)
+
+# all possible samples of interest
+all_bulk_samples <- library_metadata |>
+  dplyr::filter(
+    !(scpca_sample_id %in% cellhash_samples),
+    seq_unit == "bulk"
+  ) |>
+  dplyr::pull(scpca_sample_id) |>
+  unique()
+
+
+# keep only solid tumors with directly paired single-cell and bulk
+solid_bulk_samples <- sample_metadata |>
+  dplyr::filter(scpca_sample_id %in% all_bulk_samples) |>
+  dplyr::filter(
+    !stringr::str_detect(diagnosis, "leukemia"),
+    !stringr::str_detect(diagnosis, "Non-cancerous")
+  ) |>
+  dplyr::pull(scpca_sample_id)
+
+# Create data frame to iterate over for syncing single-cell files
+# we do this first since there are fewer single-cell than corresponding bulk
+sync_sc_df <- library_metadata |>
+  dplyr::filter(
+    scpca_sample_id %in% solid_bulk_samples,
+    seq_unit %in% c("cell", "nucleus")
+  ) |>
+  dplyr::mutate(
+    s3_dir = file.path(s3_processed_path, scpca_project_id, scpca_sample_id),
+    output_dir = file.path(opts$output_dir, scpca_project_id, scpca_sample_id)
+  ) |>
+  # only keep columns needed for syncing or checking
+  dplyr::select(
+    scpca_sample_id,
+    scpca_library_id,
+    output_dir,
+    s3_dir
+  )
+
+
+# Create data frame to iterate over for syncing bulk TPM files
+sync_bulk_tpm_df <- library_metadata |>
+  dplyr::filter(
+    scpca_sample_id %in% sync_sc_df$scpca_sample_id,
+    seq_unit == "bulk"
+  ) |>
+  dplyr::mutate(
+    s3_dir = file.path(s3_bulk_tpm_path, scpca_library_id),
+    output_dir = file.path(opts$output_dir, scpca_project_id, scpca_sample_id)
+  ) |>
+  # only keep columns needed for syncing or checking
+  dplyr::select(
+    scpca_sample_id, # this column is used for checking, not syncing
+    output_dir,
+    s3_dir
+  )
+
+
+
+# Create data frame to iterate over for syncing bulk counts TSV files
+sync_bulk_counts_df <- library_metadata |>
+  dplyr::filter(
+    scpca_sample_id %in% sync_sc_df$scpca_sample_id,
+    seq_unit == "bulk"
+  ) |>
+  dplyr::mutate(
+    s3_dir = file.path(s3_processed_path, scpca_project_id, "bulk"),
+    output_dir = file.path(opts$output_dir, scpca_project_id)
+  ) |>
+  # only keep columns needed for syncing
+  dplyr::select(
+    scpca_project_id,
+    output_dir,
+    s3_dir
+  ) |>
+  dplyr::distinct()
+
+
+# Confirm we're matching all around
+stopifnot(
+  "Bulk and single-cell samples don't match" = setequal(sync_sc_df$scpca_sample_id, sync_bulk_tpm_df$scpca_sample_id)
+)
+
+
+
+# Sync quant.sf files ------------------
+sync_bulk_tpm_df |>
+  purrr::pwalk(
+    \(scpca_sample_id, output_dir, s3_dir) {
+      # need trailing slash on s3 path
+      sync_call <- glue::glue("aws s3 sync '{s3_dir}/' '{output_dir}' --exclude '*' --include 'quant.sf'")
+      system(sync_call)
+    }
+  )
+
+
+# Sync the _processed.rds files ------------------
+sync_sc_df |>
+  purrr::pwalk(
+    \(scpca_sample_id, scpca_library_id, output_dir, s3_dir) {
+      sync_call <- glue::glue("aws s3 sync '{s3_dir}/' '{output_dir}' --exclude '*' --include '{scpca_library_id}_processed.rds'")
+      system(sync_call)
+  }
+)
+
+# Sync the bulk counts TSV files ------------------
+sync_bulk_counts_df |>
+  purrr::pwalk(
+    \(scpca_project_id, output_dir, s3_dir) {
+      sync_call <- glue::glue("aws s3 sync '{s3_dir}/' '{output_dir}' --exclude '*' --include '{scpca_project_id}_bulk_quant.tsv'")
+      system(sync_call)
+  }
+)
+# Export a TSV of mapping ensembl ids and gene symbols
+sce <- readRDS(opts$scpca_sce_file)
+data.frame(
+  ensembl_id = SingleCellExperiment::rowData(sce)$gene_ids,
+  gene_symbol = SingleCellExperiment::rowData(sce)$gene_symbol
+) |>
+  readr::write_tsv(opts$ensembl_symbol_map_file)
+
+# Export a TSV of mapping bulk library and sample ids
+library_metadata |>
+  dplyr::filter(
+    scpca_sample_id %in% sync_sc_df$scpca_sample_id,
+    seq_unit == "bulk"
+  ) |>
+  dplyr::select(scpca_sample_id, scpca_library_id) |>
+  readr::write_tsv(opts$library_sample_map_file)

--- a/analysis/pseudobulk-bulk-prediction/scripts/sync-data-files.R
+++ b/analysis/pseudobulk-bulk-prediction/scripts/sync-data-files.R
@@ -1,9 +1,9 @@
 # This script prepares files needed for analysis:
 # 1. First, we identify samples of interest as non-multiplexed samples from solid tumors with paired bulk data
 # 2. Second, we sync all associated bulk `quant.sf` files and single-cell `_processed.rds` files from S3 needed for analysis
-# 3. Third, we sync all bulk counts from `_bulkd_quant.tsv` from S3
+# 3. Third, we sync all bulk counts files `_bulk_quant.tsv` from S3
 # All files are organized in `<project id>/<sample id>/` (except bulk counts which are only per project)
-# We also export a TSV file mapping bulk library and sample ideas to support later matching up bulk counts and TPM
+# We also export a TSV file mapping bulk library and sample ids to support later matching up bulk counts and TPM
 
 
 renv::load()
@@ -130,7 +130,7 @@ sync_bulk_counts_df <- library_metadata |>
   ) |>
   # only keep columns needed for syncing
   dplyr::select(
-    scpca_project_id, 
+    scpca_project_id,
     output_dir,
     s3_dir
   ) |>


### PR DESCRIPTION
Closes #152 
This PR establishes the `analysis/estimate` directory with:
- a bash run script
- various readmes where appropriate
- a script to sync data files and export TSV maps we'll need for next steps. This script is largely the same as [this other sync script](https://github.com/AlexsLemonade/scpca-paper-figures/blob/main/analysis/pseudobulk-bulk-prediction/scripts/sync-data-files.R), except it also has parts [like this script](https://github.com/AlexsLemonade/scpca-paper-figures/blob/main/analysis/bulk-deconvolution/scripts/prepare-data-files.R) to create the gene id map tsv.

All output so far is sent to `data/` whose contents are ignored, but it is present with `.gitkeep`. I also fixed a couple typos in the original script I modeled this one after that I found while I was here.

I have run the code locally and it ran as expected to sync files and create the map TSVs.