### PR TITLE
Create geneset TSVs for ORA

### DIFF
--- a/analysis/pseudobulk-bulk-prediction/run-prediction.sh
+++ b/analysis/pseudobulk-bulk-prediction/run-prediction.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
 
 # This script runs the analysis predicting bulk from pseudobulk
+#
+# Default usage:
+# ./run-prediction.sh
+#
+# To also run the GSEA analysis, use:
+# RUN_GSEA=1 ./run-prediction.sh
+#
 
 set -euo pipefail
+
+# controls whether to run the GSEA analysis, which is very time-consuming
+RUN_GSEA=${RUN_GSEA:-0} 
 
 # Run script from its location
 basedir=$(dirname "${BASH_SOURCE[0]}")
@@ -12,6 +22,7 @@ cd "$basedir"
 data_dir="data"
 script_dir="scripts"
 scpca_dir="${data_dir}/scpca_data"
+ref_dir="${data_dir}/references"
 tpm_dir="${data_dir}/tpm"
 pseudobulk_dir="${data_dir}/pseudobulk"
 result_dir="results"
@@ -20,6 +31,7 @@ model_html_dir="${notebook_dir}/model-htmls"
 gsea_html_dir="${notebook_dir}/gsea-htmls"
 
 mkdir -p $scpca_dir
+mkdir -p $ref_dir
 mkdir -p $tpm_dir
 mkdir -p $pseudobulk_dir
 mkdir -p $result_dir
@@ -32,6 +44,7 @@ map_file="${data_dir}/bulk-library-sample-ids.tsv"
 # Sync data files from S3
 Rscript ${script_dir}/sync-data-files.R \
   --output_dir "${scpca_dir}" \
+  --reference_dir "${ref_dir}" \
   --map_file "${map_file}"
 
 # Prepare bulk counts data for comparisons
@@ -77,19 +90,23 @@ for expr_threshold in -1 0 0.25; do
 done
 
 # Run the GSEA analysis across gene sets and models
-reps=50
-for geneset in "H" "C8"; do
-  for expr_threshold in -1 0 0.25; do
-
-    if [[ ${expr_threshold} == -1 ]]; then
-      threshold_str="all-genes"
-    else
-      threshold_str="threshold-${expr_threshold}"
-    fi
-
-    Rscript -e "rmarkdown::render('${notebook_dir}/perform-gsea.Rmd',
-                params = list(msigdbr_category = '$geneset', reps = $reps, model_expr_threshold = ${expr_threshold}),
-                output_file = 'perform-gsea_${geneset}_${threshold_str}.nb.html',
-                output_dir = '${gsea_html_dir}')"
+if [[ ${RUN_GSEA} -eq 1 ]]; then
+  
+  reps=50
+  for geneset in "H" "C8"; do
+    for expr_threshold in -1 0 0.25; do
+  
+      if [[ ${expr_threshold} == -1 ]]; then
+        threshold_str="all-genes"
+      else
+        threshold_str="threshold-${expr_threshold}"
+      fi
+  
+      Rscript -e "rmarkdown::render('${notebook_dir}/perform-gsea.Rmd',
+                  params = list(msigdbr_category = '$geneset', reps = $reps, model_expr_threshold = ${expr_threshold}),
+                  output_file = 'perform-gsea_${geneset}_${threshold_str}.nb.html',
+                  output_dir = '${gsea_html_dir}')"
+    done
   done
-done
+
+fi

--- a/analysis/pseudobulk-bulk-prediction/run-prediction.sh
+++ b/analysis/pseudobulk-bulk-prediction/run-prediction.sh
@@ -12,7 +12,7 @@
 set -euo pipefail
 
 # controls whether to run the GSEA analysis, which is very time-consuming
-RUN_GSEA=${RUN_GSEA:-0} 
+RUN_GSEA=${RUN_GSEA:-0}
 
 # Run script from its location
 basedir=$(dirname "${BASH_SOURCE[0]}")
@@ -63,8 +63,8 @@ for project_dir in $scpca_dir/*; do
 
     pseudobulk_file="${pseudobulk_dir}/${project_id}_pseudobulk.tsv"
     fraction_expressed_file="${data_dir}/${project_id}_fraction-expressed-single-cell.tsv"
-    geneset_file="${data_dir}/${project_id}_panglao_genesets.tsv"
-    
+    geneset_file="${data_dir}/${project_id}_panglao-genesets.tsv"
+
     ###### TPMs are not currently used in the analysis ######
     # Calculate bulk TPM for each project
     #tpm_file="${tpm_dir}/${project_id}_tpm.tsv"
@@ -77,7 +77,7 @@ for project_dir in $scpca_dir/*; do
       --input_dir "${scpca_dir}/${project_id}" \
       --output_pseudobulk_file "${pseudobulk_file}" \
       --output_frac_expressed_file "${fraction_expressed_file}"
-      
+
     # Prepare gene set lists for over-representation analysis
     case ${project_id} in
          "SCPCP000001" | "SCPCP000002" | "SCPCP000009")
@@ -96,7 +96,7 @@ for project_dir in $scpca_dir/*; do
       --map_file "${map_file}" \
       --panglao_geneset_file "${ref_dir}/${panglao_file}" \
       --output_file "${geneset_file}"
- 
+
 done
 
 
@@ -118,17 +118,17 @@ done
 
 # Run the GSEA analysis across gene sets and models
 if [[ ${RUN_GSEA} -eq 1 ]]; then
-  
+
   reps=50
   for geneset in "H" "C8"; do
     for expr_threshold in -1 0 0.25; do
-  
+
       if [[ ${expr_threshold} == -1 ]]; then
         threshold_str="all-genes"
       else
         threshold_str="threshold-${expr_threshold}"
       fi
-  
+
       Rscript -e "rmarkdown::render('${notebook_dir}/perform-gsea.Rmd',
                   params = list(msigdbr_category = '$geneset', reps = $reps, model_expr_threshold = ${expr_threshold}),
                   output_file = 'perform-gsea_${geneset}_${threshold_str}.nb.html',

--- a/analysis/pseudobulk-bulk-prediction/run-prediction.sh
+++ b/analysis/pseudobulk-bulk-prediction/run-prediction.sh
@@ -38,6 +38,10 @@ mkdir -p $result_dir
 mkdir -p $model_html_dir
 mkdir -p $gsea_html_dir
 
+
+# this is in a different analysis directory
+consensus_celltype_dir="../estimate/data/consensus-celltypes"
+
 map_file="${data_dir}/bulk-library-sample-ids.tsv"
 
 
@@ -59,7 +63,8 @@ for project_dir in $scpca_dir/*; do
 
     pseudobulk_file="${pseudobulk_dir}/${project_id}_pseudobulk.tsv"
     fraction_expressed_file="${data_dir}/${project_id}_fraction-expressed-single-cell.tsv"
-
+    geneset_file="${data_dir}/${project_id}_panglao_genesets.tsv"
+    
     ###### TPMs are not currently used in the analysis ######
     # Calculate bulk TPM for each project
     #tpm_file="${tpm_dir}/${project_id}_tpm.tsv"
@@ -72,7 +77,28 @@ for project_dir in $scpca_dir/*; do
       --input_dir "${scpca_dir}/${project_id}" \
       --output_pseudobulk_file "${pseudobulk_file}" \
       --output_frac_expressed_file "${fraction_expressed_file}"
+      
+    # Prepare gene set lists for over-representation analysis
+    case ${project_id} in
+         "SCPCP000001" | "SCPCP000002" | "SCPCP000009")
+          panglao_file="brain-compartment_PanglaoDB_2020-03-27.tsv"
+          ;;
+        "SCPCP000006")
+          panglao_file="kidney-compartment_PanglaoDB_2020-03-27.tsv"
+          ;;
+        "SCPCP000017")
+          panglao_file="bone-and-soft-tissue_PanglaoDB_2020-03-27.tsv"
+          ;;
+      esac
+
+    Rscript ${script_dir}/prepare-ora-gene-sets.R \
+      --celltype_dir "${consensus_celltype_dir}/${project_id}" \
+      --map_file "${map_file}" \
+      --panglao_geneset_file "${ref_dir}/${panglao_file}" \
+      --output_file "${geneset_file}"
+ 
 done
+
 
 # Build and export models to results/models across different thresholds for expression
 for expr_threshold in -1 0 0.25; do
@@ -88,6 +114,7 @@ for expr_threshold in -1 0 0.25; do
               output_file = 'build-assess-models_${threshold_str}.nb.html',
               output_dir = '${model_html_dir}')"
 done
+
 
 # Run the GSEA analysis across gene sets and models
 if [[ ${RUN_GSEA} -eq 1 ]]; then

--- a/analysis/pseudobulk-bulk-prediction/scripts/README.md
+++ b/analysis/pseudobulk-bulk-prediction/scripts/README.md
@@ -10,3 +10,5 @@ The RDS file is exported to `../data/scpca_data/normalized_bulk_counts.rds`
 TSV files are exported to `../data/tpm/<project id>-tpm.tsv`.
 * `calculate-pseudobulk.R`: This script creates a TSV of pseudobulk values, using two different approaches, for all samples in a given project.
 TSV files are exported to `../data/pseudobulk/<project id>-pseudobulk.tsv`.
+* `prepare-ora-gene-sets.R`: This script prepares TSVs of consensus cell type gene sets for use in ORA.
+TSV files are exported to `../data/<project id>_panglao-genesets.tsv`.

--- a/analysis/pseudobulk-bulk-prediction/scripts/prepare-ora-gene-sets.R
+++ b/analysis/pseudobulk-bulk-prediction/scripts/prepare-ora-gene-sets.R
@@ -1,0 +1,132 @@
+# This script prepares gene sets for input to over-representation analysis (ORA) for a given ScPCA project as follows:
+# 1. Identify all unique consensus cell types across the project 
+# 2. Identify the PanglaoDB cell types that contributed to those consensus labels
+# 3. Using the scpca-nf PanglaoDB cell type reference for the given project, determine the genes in those PanglaoDB cell types
+# 4. These (unique) genes define the gene set for a given consensus cell type to test in ORA
+
+
+renv::load()
+library(optparse)
+
+
+# Parse options --------
+option_list <- list(
+  make_option(
+    "--celltype_dir",
+    type = "character",
+    help = "Directory with consensus cell types for the given project"
+  ),
+  make_option(
+    "--panglao_geneset_file",
+    type = "character",
+    help = "Path to gene set file used to cell type the given project"
+  ), 
+  make_option(
+    "--map_file",
+    type = "character",
+    help = "Path to TSV file mapping bulk sample and library ids, which is needed because not all samples are used in all projects"
+  ),
+  make_option(
+    "--output_file",
+    type = "character",
+    help = "Path to output TSV file to save gene sets."
+  ), 
+  make_option(
+    "--consensus_reference_url",
+    type = "character",
+    default = "https://raw.githubusercontent.com/AlexsLemonade/OpenScPCA-analysis/refs/heads/main/analyses/cell-type-consensus/references/consensus-cell-type-reference.tsv",
+    help = "URL with map between consensus cell types and PanglaoDB gene set labels"
+  ), 
+  make_option(
+    "--library_metadata_file",
+    type = "character",
+    default = here::here("s3_files", "scpca-library-metadata.tsv"),
+    help = "Path to ScPCA library metadata file."
+  )
+)
+opts <- parse_args(OptionParser(option_list = option_list))
+
+# Checks---------
+stopifnot(
+  "Panglao gene set file not found" = file.exists(opts$panglao_geneset_file), 
+  "Library metadata file not found" = file.exists(opts$library_metadata_file), 
+  "ID map file not found" = file.exists(opts$map_file)
+)
+
+# Prepare input files  -----------------
+consensus_ref_df <- readr::read_tsv(opts$consensus_reference_url)
+
+panglao_df <- readr::read_tsv(opts$panglao_geneset_file) |>
+  tidyr::pivot_longer(
+    -ensembl_id, 
+    names_to = "panglao_celltype", 
+    values_to = "gene_present"
+  )
+
+celltype_files <- list.files(
+  opts$celltype_dir, 
+  pattern = "_processed_consensus-cell-types\\.tsv\\.gz$", 
+  full.names = TRUE, 
+  recursive = TRUE
+) |>
+  purrr::set_names(
+    \(x) {stringr::str_split_i(basename(x), pattern = "_", i = 1)}
+  )
+
+# determine libraries to keep from the consensus cell types
+# we need to take this step because some projects don't use all their single-cell libraries
+keep_libraries <- readr::read_tsv(opts$map_file) |>
+  dplyr::select(scpca_sample_id) |>
+  dplyr::inner_join(
+    readr::read_tsv(opts$library_metadata_file)
+  ) |>
+  dplyr::filter(
+    seq_unit %in% c("nucleus", "cell"), 
+    scpca_library_id %in% names(celltype_files)
+  ) |>
+  dplyr::pull(scpca_library_id)
+
+
+# Find consensus cell type files for this project ---------------
+
+# nb, "Unknown" will still be included here, but it won't make it through the rest of the code
+present_celltypes <- celltype_files |>
+  # only keep relevant libraries
+  purrr::keep_at(
+    \(library_id) library_id %in% keep_libraries
+  ) |>
+  purrr::map(
+    \(f) {
+      readr::read_tsv(f) |>
+        dplyr::pull(consensus_annotation) 
+  }) |>
+  purrr::reduce(c) |>
+  unique()
+
+# Combine these annotations with the consensus map to get their
+# original panglao names
+consenus_panglao_df <- consensus_ref_df |>
+  dplyr::filter(consensus_annotation %in% present_celltypes) |>
+  dplyr::select(consensus_annotation, original_panglao_name) |>
+  dplyr::distinct() 
+
+# For each consensus group, determine the (unique) panglao marker genes that fed into it.
+# This creates a table with columns `gene_set_name` and `ensembl_id`
+consensus_genesets_df <- split(consenus_panglao_df, consenus_panglao_df$consensus_annotation) |>
+  purrr::map(
+    \(df) {
+      panglao_df |>
+        dplyr::filter(
+          panglao_celltype %in% df$original_panglao_name, 
+          gene_present == 1
+        ) |>
+        dplyr::select(ensembl_id) |>
+        dplyr::distinct()
+    }
+  ) |>
+  # Convert to TSV for human-readable export
+  purrr::list_rbind(names_to = "gene_set_name")
+
+
+# Export tsv file ------------------------------
+readr::write_tsv(consensus_genesets_df, opts$output_file)

--- a/analysis/pseudobulk-bulk-prediction/scripts/sync-data-files.R
+++ b/analysis/pseudobulk-bulk-prediction/scripts/sync-data-files.R
@@ -3,7 +3,8 @@
 # 2. Second, we sync all associated bulk `quant.sf` files and single-cell `_processed.rds` files from S3 needed for analysis
 # 3. Third, we sync all bulk counts files `_bulk_quant.tsv` from S3
 # All files are organized in `<project id>/<sample id>/` (except bulk counts which are only per project)
-# We also export a TSV file mapping bulk library and sample ids to support later matching up bulk counts and TPM
+# In addition, we sync PanglaoDB marker gene files used for cell type annotation for our projects of interest.
+# Finally, we also export a TSV mapping gene symbols to ensembl ids, since ESTIMATE uses gene symbols
 
 
 renv::load()
@@ -15,7 +16,12 @@ option_list <- list(
   make_option(
     "--output_dir",
     type = "character",
-    help = "Output directory to save synced data files organized by project/sample"
+    help = "Output directory to save synced ScPCA data files organized by project/sample"
+  ),
+  make_option(
+    "--reference_dir",
+    type = "character",
+    help = "Output directory to save synced PanglaoDB cell type reference files"
   ),
   make_option(
     "--map_file",
@@ -46,6 +52,7 @@ s3_bulk_tpm_path <- "s3://nextflow-ccdl-results/scpca-prod/checkpoints/salmon" #
 s3_processed_path <- "s3://nextflow-ccdl-results/scpca-prod/results" #/project_id/sample_id/library_id_processed.rds AND project_id/bulk/<project_id>_bulk_quant.tsv
 
 fs::dir_create(opts$output_dir)
+fs::dir_create(opts$reference_dir)
 
 
 ## Determine samples of interest -----------
@@ -174,7 +181,23 @@ sync_bulk_counts_df |>
 )
 
 
-# Export a TSV of matching sample and library ids for bulk, since counts TSV are labeled by library, not sample
+# Sync Panglao gene sets -------------------------
+# from https://github.com/AlexsLemonade/ScPCA-admin/blob/a2b2daf0caac336f391bac974bc1b808f29d5853/sample_info/scpca-project-celltype-metadata.tsv, we need:
+# - `brain-compartment` for SCPCP000001, SCPCP000002, and SCPCP000009
+# - `kidney-compartment` for SCPCP000006
+# - `bone-and-soft-tissue` for SCPCP000017
+
+c("brain-compartment", "kidney-compartment", "bone-and-soft-tissue") |>
+  purrr::walk(
+    \(compartment) {
+      sync_call <- glue::glue("aws s3 sync 's3://scpca-references/celltype/cellassign_references/' '{opts$reference_dir}' --exclude '*' --include '{compartment}_PanglaoDB_2020-03-27.tsv'")
+      system(sync_call)
+    }
+  )
+
+
+# Finally, export a TSV of matching sample and library ids for bulk ------------
+# we do this for later mapping because bulk counts TSV are labeled by library, not sample, ids
 bulk_libraries_samples <- library_metadata |>
   dplyr::filter(
     scpca_sample_id %in% sync_sc_df$scpca_sample_id,


### PR DESCRIPTION
Closes #168 

This PR adds a new script to establish TSV files with gene sets to use for over-representation analysis. The script prepares a TSV for a single project with this approach:
- get all consensus cell types in the project
- determine their underlying panglao cell types
- get the union of unique ensembl ids for those cell types from the Panglao cellassign reference files
- those ensembl ids comprise the gene set for the associated consensus cell type label

I also updated this analysis' sync script to include a step to download the Panglao reference files.

Note that this code lives in the `analysis/pseudobulk-bulk-prediction` directory, but the consensus cell types were previously downloaded to the `analysis/estimate` directory and I didn't think it was a good use of time to port that code into this directory, so we just point to the `estimate` directory to get those files. Also while doing this, I added an argument to the analysis run script to, by default, skip the GSEA analysis since it takes like 2 hours with all the shuffling.

The files this script exports are in the `data` directory so they are currently .gitignore'd. I'm therefore attaching them here in a zip file so you can see how they look more easily.
[panglao-geneset-tsvs.zip](https://github.com/user-attachments/files/18971272/panglao-geneset-tsvs.zip)

I think this is your first time directly reviewing code in this analysis directory, so please let me know what and where I can clarify! 