### PR TITLE
Add script to sync consensus celltype results 

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -35,6 +35,15 @@ To run the script use the following command:
 op run -- Rscript sync-reference-files.R
 ```
 
+4.`sync-consensus-celltype-results.R`: This script is used to sync the results from the `cell-type-consensus` module of [`OpenScPCA-nf`](https://github.com/AlexsLemonade/OpenScPCA-nf).
+All output files will be saved to a folder within the root directory of this repo named `s3_files/cell-type-consensus-results`. 
+In order to generate some of the figures (see more on which figures require this script below), this script will be need to run first.
+To run the script you will first need to login to your AWS account with access to `s3://openscpca-nf-workflow-results` and then run the script with the following command: 
+
+```sh
+Rscript sync-consensus-celltype-results.R --profile <name of AWS profile> 
+```
+
 ## Generating figures and tables
 
 The following scripts can be used to generate figures and tables:

--- a/scripts/figure_setup/sync-consensus-celltype-results.R
+++ b/scripts/figure_setup/sync-consensus-celltype-results.R
@@ -1,0 +1,42 @@
+#!/usr/bin/env Rscript
+
+# This script is used to download the consensus cell type results from OpenScPCA-nf
+# All files will be saved in a folder named `s3_files/cell-type-consensus-results`
+
+renv::load()
+
+library(optparse)
+
+# set up arguments
+option_list <- list(
+  make_option(
+    opt_str = c("--profile"),
+    type = "character",
+    help = "name of AWS profile to use for copying files"
+  )
+)
+
+opt <- parse_args(OptionParser(option_list = option_list))
+
+stopifnot(
+  "Must provide an aws profile using --profile" = !is.null(opt$profile)
+)
+
+# read in the project whitelist
+project_whitelist_file <- here::here("sample-info", "project-whitelist.txt")
+project_ids <- readLines(project_whitelist_file)
+
+# where openscpca results live
+s3_results_bucket <- "s3://openscpca-nf-workflow-results/2024-11-25/cell-type-consensus"
+all_s3_dirs <- glue::glue("{s3_results_bucket}/{project_ids}")
+
+# specify local directories and create them 
+local_results_dir <- here::here("s3_files", "cell-type-consensus-results")
+all_results_dir <- glue::glue("{local_results_dir}/{project_ids}")
+fs::dir_create(all_results_dir)
+
+# copy files with cell type results and gene expression tsvs for each sample
+glue::glue(
+  "aws s3 cp '{all_s3_dirs}' '{all_results_dir}' --exclude '*' --include '*_consensus-cell-types.tsv.gz' --include '*_marker-gene-expression.tsv.gz' --profile {opt$profile} --recursive"
+) |>
+  purrr::walk(system)


### PR DESCRIPTION
In preparation to add figures that use the consensus cell type results, here I'm adding a script to the `figure_setup` folder that copies the output from consensus cell typing present in the workflow results bucket from OpenScPCA. 

We already had a script to sync data from S3, but I chose to do this separately since it uses openscpca results and we need an AWS profile. It's also a lot of files so it seemed like it deserved it's own script. 