### PR TITLE
Try duckplyr for memory efficiency

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -961,10 +961,9 @@
       "Description": "Cover-tree and kd-tree fast k-nearest neighbor search algorithms and related applications including KNN classification, regression and information measures are implemented.",
       "License": "GPL (>= 2)",
       "NeedsCompilation": "yes",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Author": "Alina Beygelzimer [aut] (cover tree library), Sham Kakadet [aut] (cover tree library), John Langford [aut] (cover tree library), Sunil Arya [aut] (ANN library 1.1.2 for the kd-tree approach), David Mount [aut] (ANN library 1.1.2 for the kd-tree approach), Shengqiao Li [aut, cre]",
-      "Maintainer": "Shengqiao Li <lishengqiao@yahoo.com>",
-      "Encoding": "UTF-8"
+      "Maintainer": "Shengqiao Li <lishengqiao@yahoo.com>"
     },
     "Formula": {
       "Package": "Formula",
@@ -1451,8 +1450,7 @@
       "NeedsCompilation": "yes",
       "Author": "Brian Ripley [aut, cre, cph], Bill Venables [aut, cph], Douglas M. Bates [ctb], Kurt Hornik [trl] (partial port ca 1998), Albrecht Gebhardt [trl] (partial port ca 1998), David Firth [ctb] (support functions for polr)",
       "Maintainer": "Brian Ripley <Brian.Ripley@R-project.org>",
-      "Repository": "RSPM",
-      "Encoding": "UTF-8"
+      "Repository": "CRAN"
     },
     "Matrix": {
       "Package": "Matrix",
@@ -1616,8 +1614,7 @@
       "URL": "https://github.com/HenrikBengtsson/R.oo",
       "BugReports": "https://github.com/HenrikBengtsson/R.oo/issues",
       "NeedsCompilation": "no",
-      "Repository": "RSPM",
-      "Encoding": "UTF-8"
+      "Repository": "CRAN"
     },
     "R.utils": {
       "Package": "R.utils",
@@ -2895,8 +2892,7 @@
       "NeedsCompilation": "yes",
       "Author": "Steve Dutky [aut] (S original; then (after MM's port) revised and modified), Martin Maechler [cre, aut] (Initial R port; tweaks, <https://orcid.org/0000-0002-8685-9910>)",
       "Maintainer": "Martin Maechler <maechler@stat.math.ethz.ch>",
-      "Repository": "CRAN",
-      "Encoding": "UTF-8"
+      "Repository": "CRAN"
     },
     "blob": {
       "Package": "blob",
@@ -3504,8 +3500,7 @@
       "URL": "https://svn.r-project.org/R-packages/trunk/cluster/",
       "NeedsCompilation": "yes",
       "Author": "Martin Maechler [aut, cre] (<https://orcid.org/0000-0002-8685-9910>), Peter Rousseeuw [aut] (Fortran original, <https://orcid.org/0000-0002-3807-5353>), Anja Struyf [aut] (S original), Mia Hubert [aut] (S original, <https://orcid.org/0000-0001-6398-4850>), Kurt Hornik [trl, ctb] (port to R; maintenance(1999-2000), <https://orcid.org/0000-0003-4198-9911>), Matthias Studer [ctb], Pierre Roudier [ctb], Juan Gonzalez [ctb], Kamil Kozlowski [ctb], Erich Schubert [ctb] (fastpam options for pam(), <https://orcid.org/0000-0001-9143-4880>), Keefe Murphy [ctb] (volume.ellipsoid({d >= 3}))",
-      "Repository": "RSPM",
-      "Encoding": "UTF-8"
+      "Repository": "CRAN"
     },
     "clusterProfiler": {
       "Package": "clusterProfiler",
@@ -3583,6 +3578,28 @@
       "License": "GPL",
       "NeedsCompilation": "no",
       "Repository": "CRAN"
+    },
+    "collections": {
+      "Package": "collections",
+      "Version": "0.3.7",
+      "Source": "Repository",
+      "Type": "Package",
+      "Title": "High Performance Container Data Types",
+      "Date": "2023-01-03",
+      "Authors@R": "c(person(given = \"Randy\", family = \"Lai\", role = c(\"aut\", \"cre\"), email = \"randy.cs.lai@gmail.com\"), person(given = \"Andrea\", family = \"Mazzoleni\", role = \"cph\", comment = \"tommy hash table library\"), person(given = \"Yann\", family = \"Collet\", role = \"cph\", comment = \"xxhash algorithm\"))",
+      "Description": "Provides high performance container data types such as queues, stacks, deques, dicts and ordered dicts. Benchmarks <https://randy3k.github.io/collections/articles/benchmark.html> have shown that these containers are asymptotically more efficient than those offered by other packages.",
+      "License": "MIT + file LICENSE",
+      "URL": "https://github.com/randy3k/collections/",
+      "Suggests": [
+        "testthat (>= 2.3.1)"
+      ],
+      "ByteCompile": "yes",
+      "Encoding": "UTF-8",
+      "NeedsCompilation": "yes",
+      "RoxygenNote": "7.1.0",
+      "Author": "Randy Lai [aut, cre], Andrea Mazzoleni [cph] (tommy hash table library), Yann Collet [cph] (xxhash algorithm)",
+      "Maintainer": "Randy Lai <randy.cs.lai@gmail.com>",
+      "Repository": "RSPM"
     },
     "colorspace": {
       "Package": "colorspace",
@@ -4117,6 +4134,120 @@
       "NeedsCompilation": "yes",
       "Author": "Ralf Stubner [aut, cre] (<https://orcid.org/0009-0009-1908-106X>), daqana GmbH [cph], David Blackman [cph] (Xoroshiro / Xoshiro family), Melissa O'Neill [cph] (PCG family), Sebastiano Vigna [cph] (Xoroshiro / Xoshiro family), Aaron Lun [ctb], Kyle Butts [ctb], Henrik Sloot [ctb], Philippe Grosjean [ctb] (<https://orcid.org/0000-0002-2694-9471>)",
       "Maintainer": "Ralf Stubner <ralf.stubner@gmail.com>",
+      "Repository": "RSPM"
+    },
+    "duckdb": {
+      "Package": "duckdb",
+      "Version": "1.2.0",
+      "Source": "Repository",
+      "Title": "DBI Package for the DuckDB Database Management System",
+      "Authors@R": "c( person(\"Hannes\", \"Mühleisen\", , \"hannes@cwi.nl\", role = \"aut\", comment = c(ORCID = \"0000-0001-8552-0029\")), person(\"Mark\", \"Raasveldt\", , \"mark.raasveldt@cwi.nl\", role = \"aut\", comment = c(ORCID = \"0000-0001-5005-6844\")), person(\"Kirill\", \"Müller\", , \"kirill@cynkra.com\", role = \"cre\", comment = c(ORCID = \"0000-0002-1416-3412\")), person(\"Stichting DuckDB Foundation\", role = \"cph\"), person(\"Apache Software Foundation\", role = \"cph\"), person(\"PostgreSQL Global Development Group\", role = \"cph\"), person(\"The Regents of the University of California\", role = \"cph\"), person(\"Cameron Desrochers\", role = \"cph\"), person(\"Victor Zverovich\", role = \"cph\"), person(\"RAD Game Tools\", role = \"cph\"), person(\"Valve Software\", role = \"cph\"), person(\"Rich Geldreich\", role = \"cph\"), person(\"Tenacious Software LLC\", role = \"cph\"), person(\"The RE2 Authors\", role = \"cph\"), person(\"Google Inc.\", role = \"cph\"), person(\"Facebook Inc.\", role = \"cph\"), person(\"Steven G. Johnson\", role = \"cph\"), person(\"Jiahao Chen\", role = \"cph\"), person(\"Tony Kelman\", role = \"cph\"), person(\"Jonas Fonseca\", role = \"cph\"), person(\"Lukas Fittl\", role = \"cph\"), person(\"Salvatore Sanfilippo\", role = \"cph\"), person(\"Art.sy, Inc.\", role = \"cph\"), person(\"Oran Agra\", role = \"cph\"), person(\"Redis Labs, Inc.\", role = \"cph\"), person(\"Melissa O'Neill\", role = \"cph\"), person(\"PCG Project contributors\", role = \"cph\") )",
+      "Description": "The DuckDB project is an embedded analytical data management system with support for the Structured Query Language (SQL). This package includes all of DuckDB and an R Database Interface (DBI) connector.",
+      "License": "MIT + file LICENSE",
+      "URL": "https://r.duckdb.org/, https://github.com/duckdb/duckdb-r",
+      "BugReports": "https://github.com/duckdb/duckdb-r/issues",
+      "Depends": [
+        "DBI",
+        "R (>= 3.6.0)"
+      ],
+      "Imports": [
+        "methods",
+        "utils"
+      ],
+      "Suggests": [
+        "adbcdrivermanager",
+        "arrow (>= 13.0.0)",
+        "bit64",
+        "callr",
+        "clock",
+        "DBItest",
+        "dbplyr",
+        "dplyr",
+        "rlang",
+        "testthat",
+        "tibble",
+        "vctrs",
+        "withr"
+      ],
+      "Config/build/compilation-database": "true",
+      "Encoding": "UTF-8",
+      "RoxygenNote": "7.3.2.9000",
+      "SystemRequirements": "xz (for building from source)",
+      "NeedsCompilation": "yes",
+      "Author": "Hannes Mühleisen [aut] (<https://orcid.org/0000-0001-8552-0029>), Mark Raasveldt [aut] (<https://orcid.org/0000-0001-5005-6844>), Kirill Müller [cre] (<https://orcid.org/0000-0002-1416-3412>), Stichting DuckDB Foundation [cph], Apache Software Foundation [cph], PostgreSQL Global Development Group [cph], The Regents of the University of California [cph], Cameron Desrochers [cph], Victor Zverovich [cph], RAD Game Tools [cph], Valve Software [cph], Rich Geldreich [cph], Tenacious Software LLC [cph], The RE2 Authors [cph], Google Inc. [cph], Facebook Inc. [cph], Steven G. Johnson [cph], Jiahao Chen [cph], Tony Kelman [cph], Jonas Fonseca [cph], Lukas Fittl [cph], Salvatore Sanfilippo [cph], Art.sy, Inc. [cph], Oran Agra [cph], Redis Labs, Inc. [cph], Melissa O'Neill [cph], PCG Project contributors [cph]",
+      "Maintainer": "Kirill Müller <kirill@cynkra.com>",
+      "Repository": "RSPM"
+    },
+    "duckplyr": {
+      "Package": "duckplyr",
+      "Version": "1.0.1",
+      "Source": "Repository",
+      "Type": "Package",
+      "Title": "A 'DuckDB'-Backed Version of 'dplyr'",
+      "Authors@R": "c( person(\"Hannes\", \"Mühleisen\", role = \"aut\", comment = c(ORCID = \"0000-0001-8552-0029\")), person(\"Kirill\", \"Müller\", , \"kirill@cynkra.com\", role = c(\"aut\", \"cre\"), comment = c(ORCID = \"0000-0002-1416-3412\")), person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\")) )",
+      "Description": "A drop-in replacement for 'dplyr', powered by 'DuckDB' for performance.  Offers convenient utilities for working with in-memory and larger-than-memory data while retaining full 'dplyr' compatibility.",
+      "License": "MIT + file LICENSE",
+      "URL": "https://duckplyr.tidyverse.org, https://github.com/tidyverse/duckplyr",
+      "BugReports": "https://github.com/tidyverse/duckplyr/issues",
+      "Depends": [
+        "R (>= 4.0.0)",
+        "dplyr (>= 1.1.4)"
+      ],
+      "Imports": [
+        "cli",
+        "collections",
+        "DBI",
+        "duckdb (>= 1.2.0)",
+        "glue",
+        "jsonlite",
+        "lifecycle",
+        "magrittr",
+        "memoise",
+        "pillar (>= 1.10.1)",
+        "rlang (>= 1.0.6)",
+        "tibble",
+        "tidyselect",
+        "utils",
+        "vctrs (>= 0.6.3)"
+      ],
+      "Suggests": [
+        "arrow",
+        "brio",
+        "callr",
+        "conflicted",
+        "constructive (>= 1.0.0)",
+        "curl",
+        "dbplyr",
+        "hms",
+        "knitr",
+        "lobstr",
+        "lubridate",
+        "nycflights13",
+        "palmerpenguins",
+        "prettycode",
+        "purrr",
+        "readr",
+        "rmarkdown",
+        "testthat (>= 3.1.5)",
+        "usethis",
+        "withr"
+      ],
+      "Enhances": [
+        "qs",
+        "reprex",
+        "rstudioapi"
+      ],
+      "Config/Needs/check": "anthonynorth/roxyglobals",
+      "Config/Needs/website": "tidyverse/tidytemplate, dbplyr, rmarkdown",
+      "Config/testthat/edition": "3",
+      "Config/testthat/parallel": "false",
+      "Config/testthat/start-first": "rel_api, tpch, as_duckplyr_df, dplyr-mutate, dplyr-filter, dplyr-count-tally",
+      "Encoding": "UTF-8",
+      "RoxygenNote": "7.3.2.9000",
+      "VignetteBuilder": "knitr",
+      "NeedsCompilation": "no",
+      "Author": "Hannes Mühleisen [aut] (<https://orcid.org/0000-0001-8552-0029>), Kirill Müller [aut, cre] (<https://orcid.org/0000-0002-1416-3412>), Posit Software, PBC [cph, fnd]",
+      "Maintainer": "Kirill Müller <kirill@cynkra.com>",
       "Repository": "RSPM"
     },
     "edgeR": {
@@ -7133,8 +7264,7 @@
       "NeedsCompilation": "yes",
       "Author": "Brian Ripley [aut, cre, cph], William Venables [cph]",
       "Maintainer": "Brian Ripley <Brian.Ripley@R-project.org>",
-      "Repository": "RSPM",
-      "Encoding": "UTF-8"
+      "Repository": "CRAN"
     },
     "numDeriv": {
       "Package": "numDeriv",
@@ -7333,7 +7463,7 @@
     },
     "pillar": {
       "Package": "pillar",
-      "Version": "1.10.0",
+      "Version": "1.10.1",
       "Source": "Repository",
       "Title": "Coloured Formatting for Columns",
       "Authors@R": "c(person(given = \"Kirill\", family = \"M\\u00fcller\", role = c(\"aut\", \"cre\"), email = \"kirill@cynkra.com\", comment = c(ORCID = \"0000-0002-1416-3412\")), person(given = \"Hadley\", family = \"Wickham\", role = \"aut\"), person(given = \"RStudio\", role = \"cph\"))",
@@ -9046,8 +9176,7 @@
       "NeedsCompilation": "yes",
       "Author": "Terry M Therneau [aut, cre], Thomas Lumley [ctb, trl] (original S->R port and R maintainer until 2009), Atkinson Elizabeth [ctb], Crowson Cynthia [ctb]",
       "Maintainer": "Terry M Therneau <therneau.terry@mayo.edu>",
-      "Repository": "RSPM",
-      "Encoding": "UTF-8"
+      "Repository": "CRAN"
     },
     "svMisc": {
       "Package": "svMisc",

--- a/scripts/Fig5A-S6_consensus-cell-type-dotplots.R
+++ b/scripts/Fig5A-S6_consensus-cell-type-dotplots.R
@@ -9,7 +9,8 @@ renv::load()
 
 library(ggplot2)
 library(patchwork)
-library(dplyr)
+
+options(readr.show_col_types = FALSE)
 
 celltype_plotting_functions <- here::here("scripts", "utils", "consensus-celltype-plotting-functions.R")
 source(celltype_plotting_functions) # imports `marker_gene_dotplot()`
@@ -21,7 +22,7 @@ pdf_dir <- here::here("figures", "pdfs")
 # Define paths to individual files 
 output_pdf_files <- c(
   "Brain and CNS" = file.path(pdf_dir, "Fig5A_brain-dotplot.pdf"),
-  # "Leukemia" = file.path(pdf_dir, "FigS6A_leukemia-dotplot.pdf")
+  "Leukemia" = file.path(pdf_dir, "FigS6A_leukemia-dotplot.pdf"),
   "Sarcoma" = file.path(pdf_dir, "FigS6B_sarcoma-dotplot.pdf"),
   "Other solid tumors" = file.path(pdf_dir, "FigS6C_other-solid-tumors-dotplot.pdf")
 )
@@ -52,31 +53,31 @@ celltype_colors <- readr::read_tsv(color_palette_file) |>
 project_whitelist <- readLines(project_whitelist_file)
 
 # read in validation markers as data.tables
-markers_df <- readr::read_tsv(marker_gene_table_url, show_col_types = FALSE) |> 
+markers_df <- readr::read_tsv(marker_gene_table_url) |> 
   # only keep genes unique to a single cell type except HPC which doesn't have any unique genes
   # for HPC we keep all 6 marker genes
-  filter(gene_observed_count == 1 | validation_group_annotation == "hematopoietic precursor cell")
+  dplyr::filter(gene_observed_count == 1 | validation_group_annotation == "hematopoietic precursor cell")
 
-validation_groups_df <- readr::read_tsv(validation_group_url, show_col_types = FALSE) |> 
+validation_groups_df <- readr::read_tsv(validation_group_url) |> 
   # rename final assigned group to avoid conflicts when merging in marker gene expression 
   # we want to separate the marker gene group from the actual cell type annotation
-  select(consensus_annotation, broad_celltype_group = validation_group_annotation)
+  dplyr::select(consensus_annotation, broad_celltype_group = validation_group_annotation)
 
 # read in diagnosis groupings
-diagnosis_group_df <- readr::read_tsv(diagnosis_groupings_file, show_col_types = FALSE) |> 
-  select(diagnosis = submitted_diagnosis,
+diagnosis_group_df <- readr::read_tsv(diagnosis_groupings_file) |> 
+  dplyr::select(diagnosis = submitted_diagnosis,
                 diagnosis_group)
 
 # get sample information
-sample_df <- readr::read_tsv(sample_metadata_file, show_col_types = FALSE) |> 
-  filter(scpca_project_id %in% project_whitelist) |> 
-  left_join(diagnosis_group_df, by = c("diagnosis"))
+sample_df <- readr::read_tsv(sample_metadata_file) |> 
+  dplyr::filter(scpca_project_id %in% project_whitelist) |> 
+  dplyr::left_join(diagnosis_group_df, by = c("diagnosis"))
 
 # pull out those that are non-multiplex single cell/nuc
-non_multiplex_samples <- readr::read_tsv(library_metadata_file, show_col_types = FALSE) |> 
-  filter(!stringr::str_detect(scpca_sample_id, ";"),
+non_multiplex_samples <- readr::read_tsv(library_metadata_file) |> 
+  dplyr::filter(!stringr::str_detect(scpca_sample_id, ";"),
                 seq_unit %in% c("cell", "nucleus")) |> 
-  pull(scpca_sample_id)
+  dplyr::pull(scpca_sample_id)
 
 # Create dot plots -------------------------------------------------------------
 plot_list <- output_pdf_files |> 
@@ -84,8 +85,8 @@ plot_list <- output_pdf_files |>
     
     # get only samples in that diag group
     ids <- sample_df |> 
-      filter(diagnosis_group == group, scpca_sample_id %in% non_multiplex_samples) |> 
-      pull(scpca_sample_id)
+      dplyr::filter(diagnosis_group == group, scpca_sample_id %in% non_multiplex_samples) |> 
+      dplyr::pull(scpca_sample_id)
     
     message(glue::glue("Creating dot plot for {group}"))
     
@@ -100,7 +101,7 @@ plot_list <- output_pdf_files |>
     
     # save plot 
     ggsave(file, plot = combined_plot, width = 23, height = 10)
-    
+    gc() # clean up after each run
   })
 
 

--- a/scripts/Fig5A-S6_consensus-cell-type-dotplots.R
+++ b/scripts/Fig5A-S6_consensus-cell-type-dotplots.R
@@ -9,7 +9,7 @@ renv::load()
 
 library(ggplot2)
 library(patchwork)
-library(data.table)
+library(dplyr)
 
 celltype_plotting_functions <- here::here("scripts", "utils", "consensus-celltype-plotting-functions.R")
 source(celltype_plotting_functions) # imports `marker_gene_dotplot()`
@@ -52,31 +52,31 @@ celltype_colors <- readr::read_tsv(color_palette_file) |>
 project_whitelist <- readLines(project_whitelist_file)
 
 # read in validation markers as data.tables
-markers_dt <- fread(marker_gene_table_url) |> 
+markers_df <- readr::read_tsv(marker_gene_table_url, show_col_types = FALSE) |> 
   # only keep genes unique to a single cell type except HPC which doesn't have any unique genes
   # for HPC we keep all 6 marker genes
-  dplyr::filter(gene_observed_count == 1 | validation_group_annotation == "hematopoietic precursor cell")
+  filter(gene_observed_count == 1 | validation_group_annotation == "hematopoietic precursor cell")
 
-validation_groups_dt <- fread(validation_group_url) |> 
+validation_groups_df <- readr::read_tsv(validation_group_url, show_col_types = FALSE) |> 
   # rename final assigned group to avoid conflicts when merging in marker gene expression 
   # we want to separate the marker gene group from the actual cell type annotation
-  dplyr::select(consensus_annotation, broad_celltype_group = validation_group_annotation)
+  select(consensus_annotation, broad_celltype_group = validation_group_annotation)
 
 # read in diagnosis groupings
-diagnosis_group_df <- readr::read_tsv(diagnosis_groupings_file) |> 
-  dplyr::select(diagnosis = submitted_diagnosis,
+diagnosis_group_df <- readr::read_tsv(diagnosis_groupings_file, show_col_types = FALSE) |> 
+  select(diagnosis = submitted_diagnosis,
                 diagnosis_group)
 
 # get sample information
-sample_df <- readr::read_tsv(sample_metadata_file) |> 
-  dplyr::filter(scpca_project_id %in% project_whitelist) |> 
-  dplyr::left_join(diagnosis_group_df, by = c("diagnosis"))
+sample_df <- readr::read_tsv(sample_metadata_file, show_col_types = FALSE) |> 
+  filter(scpca_project_id %in% project_whitelist) |> 
+  left_join(diagnosis_group_df, by = c("diagnosis"))
 
 # pull out those that are non-multiplex single cell/nuc
-non_multiplex_samples <- readr::read_tsv(library_metadata_file) |> 
-  dplyr::filter(!stringr::str_detect(scpca_sample_id, ";"),
+non_multiplex_samples <- readr::read_tsv(library_metadata_file, show_col_types = FALSE) |> 
+  filter(!stringr::str_detect(scpca_sample_id, ";"),
                 seq_unit %in% c("cell", "nucleus")) |> 
-  dplyr::pull(scpca_sample_id)
+  pull(scpca_sample_id)
 
 # Create dot plots -------------------------------------------------------------
 plot_list <- output_pdf_files |> 
@@ -84,8 +84,8 @@ plot_list <- output_pdf_files |>
     
     # get only samples in that diag group
     ids <- sample_df |> 
-      dplyr::filter(diagnosis_group == group, scpca_sample_id %in% non_multiplex_samples) |> 
-      dplyr::pull(scpca_sample_id)
+      filter(diagnosis_group == group, scpca_sample_id %in% non_multiplex_samples) |> 
+      pull(scpca_sample_id)
     
     message(glue::glue("Creating dot plot for {group}"))
     
@@ -93,8 +93,8 @@ plot_list <- output_pdf_files |>
     combined_plot <- marker_gene_dotplot(
       sample_ids = ids,
       consensus_results_dir,
-      validation_groups_dt,
-      markers_dt,
+      validation_groups_df,
+      markers_df,
       celltype_colors
     )
     

--- a/scripts/utils/consensus-celltype-plotting-functions.R
+++ b/scripts/utils/consensus-celltype-plotting-functions.R
@@ -42,7 +42,7 @@ marker_gene_dotplot <- function(
   # Use DuckDB for dplyr functions
   suppressMessages(duckplyr::methods_overwrite())
   
-  # # convert to duckdb (intermediate tibble to avoid duckdb error with readr objects)
+  # convert to duckdb (intermediate data frame to avoid duckdb error with readr objects)
   validation_groups_df <- as.data.frame(validation_groups_df) |> duckplyr::as_duckdb_tibble()
   markers_df <- as.data.frame(markers_df) |> duckplyr::as_duckdb_tibble()
 

--- a/scripts/utils/consensus-celltype-plotting-functions.R
+++ b/scripts/utils/consensus-celltype-plotting-functions.R
@@ -5,7 +5,6 @@
 # packages required for functions
 library(ggplot2)
 library(patchwork)
-library(duckplyr)
 
 #' Dot plot showing expression of marker genes across assigned cell types
 #'
@@ -40,33 +39,36 @@ marker_gene_dotplot <- function(
   )
   gene_exp_files <- gene_exp_files[basename(dirname(gene_exp_files)) %in% sample_ids]
 
-  # convert to duckdb (intermediate tibble to avoid duckdb error)
-  validation_groups_df <- as_tibble(validation_groups_df) |> as_duckdb_tibble()
-  markers_df <- as_tibble(markers_df) |> as_duckdb_tibble()
+  # Use DuckDB for dplyr functions
+  suppressMessages(duckplyr::methods_overwrite())
+  
+  # # convert to duckdb (intermediate tibble to avoid duckdb error with readr objects)
+  validation_groups_df <- as.data.frame(validation_groups_df) |> duckplyr::as_duckdb_tibble()
+  markers_df <- as.data.frame(markers_df) |> duckplyr::as_duckdb_tibble()
 
   # read in files directly to duckdb tables
   # specify all varchar for consensus to avoid parsing error
-  consensus_df <- read_csv_duckdb(celltype_files, options = list(sep = "\t", union_by_name = TRUE)) 
+  consensus_df <- duckplyr::read_csv_duckdb(celltype_files, options = list(sep = "\t", union_by_name = TRUE)) 
 
-  gene_exp_df <- read_csv_duckdb(gene_exp_files, options = list(sep = "\t", union_by_name = TRUE)) |>
-    mutate(detected = logcounts > 0)
+  gene_exp_df <- duckplyr::read_csv_duckdb(gene_exp_files, options = list(sep = "\t", union_by_name = TRUE)) |>
+    dplyr::mutate(detected = logcounts > 0)
 
   # Join all consensus results and marker gene info
   consensus_df <- consensus_df |>
     # add in broad cell type group which is used for plotting
     # groups similar cell types together
-    left_join(validation_groups_df, by = "consensus_annotation") |>
-    left_join(gene_exp_df, by = c("barcodes", "library_id")) |>
+    dplyr::left_join(validation_groups_df, by = "consensus_annotation") |>
+    dplyr::left_join(gene_exp_df, by = c("barcodes", "library_id")) |>
     # add marker gene information (associated validation group annotation, gene observed count, percent tissues)
     # account for the same gene being present in multiple cell types
-    left_join(markers_df, by = "ensembl_gene_id", relationship = "many-to-many")
+    dplyr::left_join(markers_df, by = "ensembl_gene_id", relationship = "many-to-many")
 
   # prep for plots
   # get total number of cells per final annotation group
   total_cells_df <- consensus_df |>
-    select(library_id, barcodes, broad_celltype_group) |>
-    distinct() |>
-    count(broad_celltype_group, name = "total_cells")
+    dplyr::select(library_id, barcodes, broad_celltype_group) |>
+    dplyr::distinct() |>
+    dplyr::count(broad_celltype_group, name = "total_cells")
 
   # table with one row per unique broad cell type/ marker gene combination
   # first all cells in with the same broad_celltype_group (determined based on consensus_annotation) are grouped together
@@ -76,27 +78,27 @@ marker_gene_dotplot <- function(
   group_stats_df <- consensus_df |>
     # for each assigned cell type/marker gene combo get total detected and mean expression
     # group by both broad group and validation group to account for genes that are expressed in more than one cell type
-    summarize(
+    dplyr::summarize(
       .by = c("broad_celltype_group", "ensembl_gene_id", "validation_group_annotation"),
       detected_count = sum(detected),
       mean_exp = mean(logcounts)
     ) |>
     # add in validation group for marker genes
     # this includes all possible marker genes and all possible validation group assignments
-    left_join(markers_df, by = c("ensembl_gene_id", "validation_group_annotation"), relationship = "many-to-many") |>
+    dplyr::left_join(markers_df, by = c("ensembl_gene_id", "validation_group_annotation"), relationship = "many-to-many") |>
     # now get the mean expression/ mean percentage across all marker genes for a given validation group
     # here the broad_celltype_group is the final assigned annotation for that group of cells
     # the validation_group_annotation refers to the cell type that marker gene is associated with
-    mutate(
+    dplyr::mutate(
       .by = c("broad_celltype_group", "validation_group_annotation"),
       # calculate mean expression/detected across all markers for a specific group
       all_markers_mean_exp = mean(mean_exp),
       all_markers_detected_count = mean(detected_count)
     ) |> # add total cells
-    left_join(total_cells_df, by = c("broad_celltype_group")) |>
+    dplyr::left_join(total_cells_df, by = c("broad_celltype_group")) |>
     # for plotting we're only going to look at any cell types with > 50 cells otherwise these plots can get wild
-    filter(total_cells > 50) |>
-    mutate(
+    dplyr::filter(total_cells > 50) |>
+    dplyr::mutate(
       # get total percent expressed
       percent_exp = (detected_count / total_cells) * 100,
       all_markers_percent_exp = (all_markers_detected_count / total_cells) * 100,
@@ -107,7 +109,7 @@ marker_gene_dotplot <- function(
 
   # get list of celltypes to keep and assign colors
   celltype_groups <- group_stats_df |>
-    pull(broad_celltype_group) |>
+    dplyr::pull(broad_celltype_group) |>
     unique() |>
     as.character()
 
@@ -115,32 +117,31 @@ marker_gene_dotplot <- function(
   # we will only plot the marker genes for cell types that are part of the assigned broad validation group for this group of samples
   # we don't care about plotting marker genes for cell types that aren't present here
   filtered_markers_df <- markers_df |>
-    filter(
+    dplyr::filter(
       validation_group_annotation %in% celltype_groups,
       gene_symbol %in% group_stats_df$gene_symbol
     )
 
   # specify x axis order for dotplot
   marker_gene_order <- filtered_markers_df |>
-    pull(gene_symbol)
+    dplyr::pull(gene_symbol)
 
   # set order for cell types
   celltype_order <- unique(filtered_markers_df$validation_group_annotation)
 
   # filter out low expressed genes
   dotplot_df <- group_stats_df |>
-    filter(mean_exp > 0, percent_exp > 10) |>
-    arrange(broad_celltype_group) |>
+    dplyr::filter(mean_exp > 0, percent_exp > 10) |>
+    dplyr::arrange(broad_celltype_group) |>
     # add a label for the plot
-    mutate(y_label = as.factor(glue::glue("{broad_celltype_group} ({total_cells})"))) |>
+    dplyr::mutate(y_label = as.factor(glue::glue("{broad_celltype_group} ({total_cells})"))) |>
     # remove marker genes that aren't present in final annotations and set x axis order
-    filter(gene_symbol %in% marker_gene_order) |>
-    mutate(
+    dplyr::filter(gene_symbol %in% marker_gene_order) |>
+    dplyr::mutate(
       # set orders of gene symbol and validation groups
       gene_symbol = factor(gene_symbol, levels = marker_gene_order),
       validation_group_annotation = factor(validation_group_annotation, levels = celltype_order)
-    ) |>
-    as_tibble()
+    )
 
 
   # make dotplot with marker gene exp
@@ -185,5 +186,6 @@ marker_gene_dotplot <- function(
   combined_plot <- color_bar / dotplot +
     patchwork::plot_layout(ncol = 1, heights = c(0.1, 4))
 
+  suppressMessages(duckplyr::methods_restore()) # back to dplyr outside the function
   return(combined_plot)
 }

--- a/scripts/utils/consensus-celltype-plotting-functions.R
+++ b/scripts/utils/consensus-celltype-plotting-functions.R
@@ -5,6 +5,7 @@
 # packages required for functions
 library(ggplot2)
 library(patchwork)
+library(data.table)
 library(duckplyr)
 
 #' Dot plot showing expression of marker genes across assigned cell types
@@ -33,21 +34,20 @@ marker_gene_dotplot <- function(
   gene_exp_files <- gene_exp_files[basename(dirname(gene_exp_files)) %in% sample_ids]
   
   # convert to duckdb
-  validation_groups_df <- as_tibble(validation_groups_df) |>  as_duckdb_tibble()
+  validation_groups_df <- validation_groups_df |>  as_duckdb_tibble()
   markers_df <- as_tibble(markers_df) |> as_duckdb_tibble()
   
   # read in files 
   consensus_df <- celltype_files |> 
-    purrr::map(readr::read_tsv, show_col_types = FALSE) |>
-    purrr::list_rbind() |>
-    as_tibble() |>
-    as_duckdb_tibble()
+    purrr::map(fread) |>
+    data.table::rbindlist(fill = TRUE, use.names = TRUE) |>
+    as_duckdb_tibble(prudence = "thrifty")
   
   gene_exp_df <- gene_exp_files |> 
-    purrr::map(readr::read_tsv, show_col_types = FALSE) |>
-    purrr::list_rbind() |>
-    as_tibble() |>
-    as_duckdb_tibble()
+    purrr::map(fread) |>
+    data.table::rbindlist(fill = TRUE, use.names = TRUE) |>
+    as_duckdb_tibble(prudence = "thrifty") |>
+    mutate(detected = logcounts > 0)
   
   # Join all consensus results and marker gene info
   consensus_df <- consensus_df |> 
@@ -57,8 +57,7 @@ marker_gene_dotplot <- function(
     left_join(gene_exp_df, by = c("barcodes", "library_id")) |> 
     # add marker gene information (associated validation group annotation, gene observed count, percent tissues)
     # account for the same gene being present in multiple cell types 
-    left_join(markers_df, by = "ensembl_gene_id", relationship = "many-to-many") |> 
-    mutate(detected = logcounts > 0)
+    left_join(markers_df, by = "ensembl_gene_id", relationship = "many-to-many")
   
   # remove extra data frame
   rm(gene_exp_df)
@@ -79,8 +78,8 @@ marker_gene_dotplot <- function(
   group_stats_df <- consensus_df |> 
     # for each assigned cell type/marker gene combo get total detected and mean expression
     # group by both broad group and validation group to account for genes that are expressed in more than one cell type
-    group_by(broad_celltype_group, ensembl_gene_id, validation_group_annotation) |>
     summarize(
+      .by = c("broad_celltype_group", "ensembl_gene_id", "validation_group_annotation"),
       detected_count = sum(detected),
       mean_exp = mean(logcounts)
     ) |> 
@@ -90,8 +89,8 @@ marker_gene_dotplot <- function(
     # now get the mean expression/ mean percentage across all marker genes for a given validation group
     # here the broad_celltype_group is the final assigned annotation for that group of cells 
     # the validation_group_annotation refers to the cell type that marker gene is associated with 
-    group_by(broad_celltype_group, validation_group_annotation) |> 
     mutate(
+      .by = c("broad_celltype_group", "validation_group_annotation"),
       # calculate mean expression/detected across all markers for a specific group 
       all_markers_mean_exp = mean(mean_exp),
       all_markers_detected_count = mean(detected_count)
@@ -99,7 +98,6 @@ marker_gene_dotplot <- function(
     left_join(total_cells_df, by = c("broad_celltype_group")) |> 
     # for plotting we're only going to look at any cell types with > 50 cells otherwise these plots can get wild 
     filter(total_cells > 50) |> 
-    rowwise() |> 
     mutate(
       # get total percent expressed
       percent_exp = (detected_count/total_cells) * 100,

--- a/scripts/utils/consensus-celltype-plotting-functions.R
+++ b/scripts/utils/consensus-celltype-plotting-functions.R
@@ -1,6 +1,6 @@
 #!/usr/bin/env Rscript
 
-# This file contains helper functions for plotting consensus cell types 
+# This file contains helper functions for plotting consensus cell types
 
 # packages required for functions
 library(ggplot2)
@@ -22,138 +22,140 @@ marker_gene_dotplot <- function(
     consensus_results_dir,
     validation_groups_df,
     markers_df,
-    celltype_colors
-){
-  
+    celltype_colors) {
   # list all cell type assignments files
-  consensus_results_files <- list.files(consensus_results_dir, pattern = "_processed_consensus-cell-types\\.tsv\\.gz$", recursive = TRUE, full.names = TRUE) 
+  consensus_results_files <- list.files(
+    consensus_results_dir,
+    pattern = "_processed_consensus-cell-types\\.tsv\\.gz$",
+    recursive = TRUE,
+    full.names = TRUE
+  )
   celltype_files <- consensus_results_files[basename(dirname(consensus_results_files)) %in% sample_ids]
-  
-  # gene expression used for dot plots 
-  gene_exp_files <- list.files(consensus_results_dir, pattern = "_processed_marker-gene-expression\\.tsv\\.gz$", recursive = TRUE, full.names = TRUE)
+
+  # gene expression used for dot plots
+  gene_exp_files <- list.files(
+    consensus_results_dir,
+    pattern = "_processed_marker-gene-expression\\.tsv\\.gz$",
+    recursive = TRUE,
+    full.names = TRUE
+  )
   gene_exp_files <- gene_exp_files[basename(dirname(gene_exp_files)) %in% sample_ids]
-  
+
   # convert to duckdb
-  validation_groups_df <- validation_groups_df |>  as_duckdb_tibble()
+  validation_groups_df <- as_tibble(validation_groups_df) |> as_duckdb_tibble()
   markers_df <- as_tibble(markers_df) |> as_duckdb_tibble()
-  
-  # read in files 
-  consensus_df <- celltype_files |> 
+
+  # read in files
+  consensus_df <- celltype_files |>
     purrr::map(fread) |>
     data.table::rbindlist(fill = TRUE, use.names = TRUE) |>
     as_duckdb_tibble(prudence = "thrifty")
-  
-  
+
+
+  # use a tempfile and read_csv_duckdb() to reduce memory usage for reading in gene expression files
   gene_exp_csv <- tempfile(fileext = ".csv")
   on.exit(unlink(gene_exp_csv), add = TRUE)
-  csv_append = FALSE
-  for (f in gene_exp_files){
+  csv_append <- FALSE
+  for (f in gene_exp_files) {
     gene_exp_df <- fread(f)
     fwrite(gene_exp_df, gene_exp_csv, append = csv_append)
-    csv_append = TRUE # after the first, append
+    csv_append <- TRUE # after the first, append
   }
-
-  gene_exp_df <- read_csv_duckdb(gene_exp_csv)|>
+  gene_exp_df <- read_csv_duckdb(gene_exp_csv) |>
     mutate(detected = logcounts > 0)
-  
+
   # Join all consensus results and marker gene info
-  consensus_df <- consensus_df |> 
+  consensus_df <- consensus_df |>
     # add in broad cell type group which is used for plotting
-    # groups similar cell types together 
-    left_join(validation_groups_df, by = "consensus_annotation") |> 
-    left_join(gene_exp_df, by = c("barcodes", "library_id")) |> 
+    # groups similar cell types together
+    left_join(validation_groups_df, by = "consensus_annotation") |>
+    left_join(gene_exp_df, by = c("barcodes", "library_id")) |>
     # add marker gene information (associated validation group annotation, gene observed count, percent tissues)
-    # account for the same gene being present in multiple cell types 
+    # account for the same gene being present in multiple cell types
     left_join(markers_df, by = "ensembl_gene_id", relationship = "many-to-many")
-  
-  # remove extra data frame
-  rm(gene_exp_df)
-  gc()
-  
-  # prep for plots 
-  # get total number of cells per final annotation group 
-  total_cells_df <- consensus_df |> 
-    select(library_id, barcodes, broad_celltype_group) |> 
-    distinct() |> 
-    count(broad_celltype_group, name = "total_cells") 
-  
-  # table with one row per unique broad cell type/ marker gene combination 
+
+  # prep for plots
+  # get total number of cells per final annotation group
+  total_cells_df <- consensus_df |>
+    select(library_id, barcodes, broad_celltype_group) |>
+    distinct() |>
+    count(broad_celltype_group, name = "total_cells")
+
+  # table with one row per unique broad cell type/ marker gene combination
   # first all cells in with the same broad_celltype_group (determined based on consensus_annotation) are grouped together
   # then get the mean gene expression and total percentage of cells that express each marker gene across all cells in that group
-  # do this for every possible marker gene/ validation group assignment 
+  # do this for every possible marker gene/ validation group assignment
   # second we calculate the mean expression and mean percentage of all marker genes in a given validation group (this value is used only in the second section of the report)
-  group_stats_df <- consensus_df |> 
+  group_stats_df <- consensus_df |>
     # for each assigned cell type/marker gene combo get total detected and mean expression
     # group by both broad group and validation group to account for genes that are expressed in more than one cell type
     summarize(
       .by = c("broad_celltype_group", "ensembl_gene_id", "validation_group_annotation"),
       detected_count = sum(detected),
       mean_exp = mean(logcounts)
-    ) |> 
+    ) |>
     # add in validation group for marker genes
-    # this includes all possible marker genes and all possible validation group assignments 
+    # this includes all possible marker genes and all possible validation group assignments
     left_join(markers_df, by = c("ensembl_gene_id", "validation_group_annotation"), relationship = "many-to-many") |>
     # now get the mean expression/ mean percentage across all marker genes for a given validation group
-    # here the broad_celltype_group is the final assigned annotation for that group of cells 
-    # the validation_group_annotation refers to the cell type that marker gene is associated with 
+    # here the broad_celltype_group is the final assigned annotation for that group of cells
+    # the validation_group_annotation refers to the cell type that marker gene is associated with
     mutate(
       .by = c("broad_celltype_group", "validation_group_annotation"),
-      # calculate mean expression/detected across all markers for a specific group 
+      # calculate mean expression/detected across all markers for a specific group
       all_markers_mean_exp = mean(mean_exp),
       all_markers_detected_count = mean(detected_count)
-    ) |>  # add total cells
-    left_join(total_cells_df, by = c("broad_celltype_group")) |> 
-    # for plotting we're only going to look at any cell types with > 50 cells otherwise these plots can get wild 
-    filter(total_cells > 50) |> 
+    ) |> # add total cells
+    left_join(total_cells_df, by = c("broad_celltype_group")) |>
+    # for plotting we're only going to look at any cell types with > 50 cells otherwise these plots can get wild
+    filter(total_cells > 50) |>
     mutate(
       # get total percent expressed
-      percent_exp = (detected_count/total_cells) * 100,
-      all_markers_percent_exp = (all_markers_detected_count/total_cells) * 100, 
+      percent_exp = (detected_count / total_cells) * 100,
+      all_markers_percent_exp = (all_markers_detected_count / total_cells) * 100,
       # account for NA/unknowns and set axes order
-      broad_celltype_group = tidyr::replace_na(broad_celltype_group, "unknown") |> 
-        factor(levels =  c(unique(markers_df$validation_group_annotation), "unknown"))
-    ) 
-  
-  # no longer need this and it takes up space 
-  rm(consensus_df)
-  gc()
-  
-  # get list of celltypes to keep and assign colors 
-  celltype_groups <- group_stats_df |> 
-    pull(broad_celltype_group) |> 
+      broad_celltype_group = tidyr::replace_na(broad_celltype_group, "unknown") |>
+        factor(levels = c(unique(markers_df$validation_group_annotation), "unknown"))
+    )
+
+  # get list of celltypes to keep and assign colors
+  celltype_groups <- group_stats_df |>
+    pull(broad_celltype_group) |>
     unique() |>
     as.character()
-  
-  # filter markers to those that are actually relevant 
+
+  # filter markers to those that are actually relevant
   # we will only plot the marker genes for cell types that are part of the assigned broad validation group for this group of samples
-  # we don't care about plotting marker genes for cell types that aren't present here 
-  filtered_markers_df <- markers_df |> 
-    filter(validation_group_annotation %in% celltype_groups,
-                  gene_symbol %in% group_stats_df$gene_symbol)
+  # we don't care about plotting marker genes for cell types that aren't present here
+  filtered_markers_df <- markers_df |>
+    filter(
+      validation_group_annotation %in% celltype_groups,
+      gene_symbol %in% group_stats_df$gene_symbol
+    )
 
   # specify x axis order for dotplot
-  marker_gene_order <- filtered_markers_df |> 
+  marker_gene_order <- filtered_markers_df |>
     pull(gene_symbol)
-  
-  # set order for cell types 
+
+  # set order for cell types
   celltype_order <- unique(filtered_markers_df$validation_group_annotation)
-  
+
   # filter out low expressed genes
-  dotplot_df <- group_stats_df |> 
-    filter(mean_exp > 0, percent_exp > 10) |> 
-    arrange(broad_celltype_group) |> 
-    # add a label for the plot 
-    mutate(y_label = as.factor(glue::glue("{broad_celltype_group} ({total_cells})"))) |> 
-    # remove marker genes that aren't present in final annotations and set x axis order 
-    filter(gene_symbol %in% marker_gene_order) |> 
+  dotplot_df <- group_stats_df |>
+    filter(mean_exp > 0, percent_exp > 10) |>
+    arrange(broad_celltype_group) |>
+    # add a label for the plot
+    mutate(y_label = as.factor(glue::glue("{broad_celltype_group} ({total_cells})"))) |>
+    # remove marker genes that aren't present in final annotations and set x axis order
+    filter(gene_symbol %in% marker_gene_order) |>
     mutate(
-      # set orders of gene symbol and validation groups 
+      # set orders of gene symbol and validation groups
       gene_symbol = factor(gene_symbol, levels = marker_gene_order),
       validation_group_annotation = factor(validation_group_annotation, levels = celltype_order)
     ) |>
     as_tibble()
-  
-  
+
+
   # make dotplot with marker gene exp
   dotplot <- ggplot(dotplot_df, aes(y = forcats::fct_rev(y_label), x = gene_symbol, color = mean_exp, size = percent_exp)) +
     geom_point() +
@@ -163,7 +165,7 @@ marker_gene_dotplot <- function(
     theme(
       strip.background = element_rect(fill = "transparent", color = NA),
       strip.placement = "outside",
-      strip.text.x = element_blank(), 
+      strip.text.x = element_blank(),
       axis.text.x = element_text(angle = 90, hjust = 1, vjust = 0.5),
       axis.ticks.x = element_blank(),
       text = element_text(size = 14),
@@ -174,12 +176,12 @@ marker_gene_dotplot <- function(
       y = "Broad cell type annotation",
       color = "Mean gene expression",
       size = "Percent cells expressed"
-    ) 
-  
-  
-  # add annotation bar aligning marker genes with validation group 
-  color_bar <- ggplot(dotplot_df, aes(x = gene_symbol, y = 1, fill = validation_group_annotation)) + 
-    geom_tile() + 
+    )
+
+
+  # add annotation bar aligning marker genes with validation group
+  color_bar <- ggplot(dotplot_df, aes(x = gene_symbol, y = 1, fill = validation_group_annotation)) +
+    geom_tile() +
     facet_grid(cols = vars(validation_group_annotation), scales = "free", space = "free") +
     scale_fill_manual(values = celltype_colors, breaks = levels(dotplot_df$validation_group_annotation)) +
     ggmap::theme_nothing() +
@@ -190,11 +192,11 @@ marker_gene_dotplot <- function(
       legend.position = "none",
       panel.spacing = unit(0.5, "lines"),
       strip.clip = "off"
-      ) +
+    ) +
     labs(fill = "")
-  
+
   combined_plot <- color_bar / dotplot +
-    patchwork::plot_layout(ncol = 1, heights = c(0.1, 4)) 
+    patchwork::plot_layout(ncol = 1, heights = c(0.1, 4))
 
   return(combined_plot)
 }

--- a/scripts/utils/consensus-celltype-plotting-functions.R
+++ b/scripts/utils/consensus-celltype-plotting-functions.R
@@ -5,7 +5,6 @@
 # packages required for functions
 library(ggplot2)
 library(patchwork)
-library(data.table)
 library(duckplyr)
 
 #' Dot plot showing expression of marker genes across assigned cell types

--- a/scripts/utils/consensus-celltype-plotting-functions.R
+++ b/scripts/utils/consensus-celltype-plotting-functions.R
@@ -43,10 +43,17 @@ marker_gene_dotplot <- function(
     data.table::rbindlist(fill = TRUE, use.names = TRUE) |>
     as_duckdb_tibble(prudence = "thrifty")
   
-  gene_exp_df <- gene_exp_files |> 
-    purrr::map(fread) |>
-    data.table::rbindlist(fill = TRUE, use.names = TRUE) |>
-    as_duckdb_tibble(prudence = "thrifty") |>
+  
+  gene_exp_csv <- tempfile(fileext = ".csv")
+  on.exit(unlink(gene_exp_csv), add = TRUE)
+  csv_append = FALSE
+  for (f in gene_exp_files){
+    gene_exp_df <- fread(f)
+    fwrite(gene_exp_df, gene_exp_csv, append = csv_append)
+    csv_append = TRUE # after the first, append
+  }
+
+  gene_exp_df <- read_csv_duckdb(gene_exp_csv)|>
     mutate(detected = logcounts > 0)
   
   # Join all consensus results and marker gene info

--- a/scripts/utils/consensus-celltype-plotting-functions.R
+++ b/scripts/utils/consensus-celltype-plotting-functions.R
@@ -41,7 +41,7 @@ marker_gene_dotplot <- function(
   )
   gene_exp_files <- gene_exp_files[basename(dirname(gene_exp_files)) %in% sample_ids]
 
-  # convert to duckdb
+  # convert to duckdb (intermediate tibble to avoid duckdb error)
   validation_groups_df <- as_tibble(validation_groups_df) |> as_duckdb_tibble()
   markers_df <- as_tibble(markers_df) |> as_duckdb_tibble()
 

--- a/scripts/utils/consensus-celltype-plotting-functions.R
+++ b/scripts/utils/consensus-celltype-plotting-functions.R
@@ -21,6 +21,7 @@ marker_gene_dotplot <- function(
     validation_groups_df,
     markers_df,
     celltype_colors) {
+  
   # list all cell type assignments files
   consensus_results_files <- list.files(
     consensus_results_dir,
@@ -85,23 +86,13 @@ marker_gene_dotplot <- function(
     ) |>
     # add in validation group for marker genes
     # this includes all possible marker genes and all possible validation group assignments
-    dplyr::left_join(markers_df, by = c("ensembl_gene_id", "validation_group_annotation"), relationship = "many-to-many") |>
-    # now get the mean expression/ mean percentage across all marker genes for a given validation group
-    # here the broad_celltype_group is the final assigned annotation for that group of cells
-    # the validation_group_annotation refers to the cell type that marker gene is associated with
-    dplyr::mutate(
-      .by = c("broad_celltype_group", "validation_group_annotation"),
-      # calculate mean expression/detected across all markers for a specific group
-      all_markers_mean_exp = mean(mean_exp),
-      all_markers_detected_count = mean(detected_count)
-    ) |> # add total cells
+    dplyr::left_join(markers_df, by = c("ensembl_gene_id", "validation_group_annotation"), relationship = "many-to-many") |> # add total cells
     dplyr::left_join(total_cells_df, by = c("broad_celltype_group")) |>
     # for plotting we're only going to look at any cell types with > 50 cells otherwise these plots can get wild
     dplyr::filter(total_cells > 50) |>
     dplyr::mutate(
       # get total percent expressed
       percent_exp = (detected_count / total_cells) * 100,
-      all_markers_percent_exp = (all_markers_detected_count / total_cells) * 100,
       # account for NA/unknowns and set axes order
       broad_celltype_group = tidyr::replace_na(broad_celltype_group, "unknown") |>
         factor(levels = c(unique(markers_df$validation_group_annotation), "unknown"))
@@ -139,6 +130,7 @@ marker_gene_dotplot <- function(
     dplyr::filter(gene_symbol %in% marker_gene_order) |>
     dplyr::mutate(
       # set orders of gene symbol and validation groups
+      y_label = factor(y_label, levels = unique(y_label)),
       gene_symbol = factor(gene_symbol, levels = marker_gene_order),
       validation_group_annotation = factor(validation_group_annotation, levels = celltype_order)
     )

--- a/scripts/utils/consensus-celltype-plotting-functions.R
+++ b/scripts/utils/consensus-celltype-plotting-functions.R
@@ -5,22 +5,22 @@
 # packages required for functions
 library(ggplot2)
 library(patchwork)
-library(data.table)
+library(duckplyr)
 
 #' Dot plot showing expression of marker genes across assigned cell types
 #'
 #' @param sample_ids Character vector of ScPCA sample ids to include in plot
 #' @param consensus_results_dir Directory where results from cell-type-consensus module of OpenScPCA-nf lives
-#' @param validation_groups_dt Data frame assigning consensus cell types to broader validation groups
-#' @param markers_dt Data frame with marker genes for each cell type
+#' @param validation_groups_df Data frame assigning consensus cell types to broader validation groups
+#' @param markers_df Data frame with marker genes for each cell type
 #' @param celltype_colors Named vector of colors to use for each broader validation group
 #'
 #' @returns Dot plot with summarized expression of marker genes for consensus cell types
 marker_gene_dotplot <- function(
     sample_ids,
     consensus_results_dir,
-    validation_groups_dt,
-    markers_dt,
+    validation_groups_df,
+    markers_df,
     celltype_colors
 ){
   
@@ -32,112 +32,121 @@ marker_gene_dotplot <- function(
   gene_exp_files <- list.files(consensus_results_dir, pattern = "_processed_marker-gene-expression\\.tsv\\.gz$", recursive = TRUE, full.names = TRUE)
   gene_exp_files <- gene_exp_files[basename(dirname(gene_exp_files)) %in% sample_ids]
   
-  # read in files 
-  consensus_dt <- celltype_files |> 
-    purrr::map(fread) |>
-    data.table::rbindlist(fill = TRUE, use.names = TRUE) 
+  # convert to duckdb
+  validation_groups_df <- as_tibble(validation_groups_df) |>  as_duckdb_tibble()
+  markers_df <- as_tibble(markers_df) |> as_duckdb_tibble()
   
-  gene_exp_dt <- gene_exp_files |> 
-    purrr::map(fread) |> 
-    data.table::rbindlist(fill = TRUE, use.names = TRUE)
+  # read in files 
+  consensus_df <- celltype_files |> 
+    purrr::map(readr::read_tsv, show_col_types = FALSE) |>
+    purrr::list_rbind() |>
+    as_tibble() |>
+    as_duckdb_tibble()
+  
+  gene_exp_df <- gene_exp_files |> 
+    purrr::map(readr::read_tsv, show_col_types = FALSE) |>
+    purrr::list_rbind() |>
+    as_tibble() |>
+    as_duckdb_tibble()
   
   # Join all consensus results and marker gene info
-  consensus_dt <- consensus_dt |> 
+  consensus_df <- consensus_df |> 
     # add in broad cell type group which is used for plotting
     # groups similar cell types together 
-    dplyr::left_join(validation_groups_dt, by = "consensus_annotation") |> 
-    dplyr::left_join(gene_exp_dt, by = c("barcodes", "library_id")) |> 
+    left_join(validation_groups_df, by = "consensus_annotation") |> 
+    left_join(gene_exp_df, by = c("barcodes", "library_id")) |> 
     # add marker gene information (associated validation group annotation, gene observed count, percent tissues)
     # account for the same gene being present in multiple cell types 
-    dplyr::left_join(markers_dt, by = "ensembl_gene_id", relationship = "many-to-many") |> 
-    dplyr::mutate(detected = logcounts > 0)
+    left_join(markers_df, by = "ensembl_gene_id", relationship = "many-to-many") |> 
+    mutate(detected = logcounts > 0)
   
   # remove extra data frame
-  rm(gene_exp_dt)
+  rm(gene_exp_df)
   gc()
   
   # prep for plots 
   # get total number of cells per final annotation group 
-  total_cells_df <- consensus_dt |> 
-    dplyr::select(library_id, barcodes, broad_celltype_group) |> 
-    dplyr::distinct() |> 
-    dplyr::count(broad_celltype_group, name = "total_cells") 
+  total_cells_df <- consensus_df |> 
+    select(library_id, barcodes, broad_celltype_group) |> 
+    distinct() |> 
+    count(broad_celltype_group, name = "total_cells") 
   
   # table with one row per unique broad cell type/ marker gene combination 
   # first all cells in with the same broad_celltype_group (determined based on consensus_annotation) are grouped together
   # then get the mean gene expression and total percentage of cells that express each marker gene across all cells in that group
   # do this for every possible marker gene/ validation group assignment 
   # second we calculate the mean expression and mean percentage of all marker genes in a given validation group (this value is used only in the second section of the report)
-  group_stats_df <- consensus_dt |> 
+  group_stats_df <- consensus_df |> 
     # for each assigned cell type/marker gene combo get total detected and mean expression
     # group by both broad group and validation group to account for genes that are expressed in more than one cell type
-    dplyr::group_by(broad_celltype_group, ensembl_gene_id, validation_group_annotation) |>
-    dplyr::summarize(
+    group_by(broad_celltype_group, ensembl_gene_id, validation_group_annotation) |>
+    summarize(
       detected_count = sum(detected),
       mean_exp = mean(logcounts)
     ) |> 
     # add in validation group for marker genes
     # this includes all possible marker genes and all possible validation group assignments 
-    dplyr::left_join(markers_dt, by = c("ensembl_gene_id", "validation_group_annotation"), relationship = "many-to-many") |>
+    left_join(markers_df, by = c("ensembl_gene_id", "validation_group_annotation"), relationship = "many-to-many") |>
     # now get the mean expression/ mean percentage across all marker genes for a given validation group
     # here the broad_celltype_group is the final assigned annotation for that group of cells 
     # the validation_group_annotation refers to the cell type that marker gene is associated with 
-    dplyr::group_by(broad_celltype_group, validation_group_annotation) |> 
-    dplyr::mutate(
+    group_by(broad_celltype_group, validation_group_annotation) |> 
+    mutate(
       # calculate mean expression/detected across all markers for a specific group 
       all_markers_mean_exp = mean(mean_exp),
       all_markers_detected_count = mean(detected_count)
     ) |>  # add total cells
-    dplyr::left_join(total_cells_df, by = c("broad_celltype_group")) |> 
+    left_join(total_cells_df, by = c("broad_celltype_group")) |> 
     # for plotting we're only going to look at any cell types with > 50 cells otherwise these plots can get wild 
-    dplyr::filter(total_cells > 50) |> 
-    dplyr::rowwise() |> 
-    dplyr::mutate(
+    filter(total_cells > 50) |> 
+    rowwise() |> 
+    mutate(
       # get total percent expressed
       percent_exp = (detected_count/total_cells) * 100,
       all_markers_percent_exp = (all_markers_detected_count/total_cells) * 100, 
       # account for NA/unknowns and set axes order
       broad_celltype_group = tidyr::replace_na(broad_celltype_group, "unknown") |> 
-        factor(levels =  c(unique(markers_dt$validation_group_annotation), "unknown"))
+        factor(levels =  c(unique(markers_df$validation_group_annotation), "unknown"))
     ) 
   
   # no longer need this and it takes up space 
-  rm(consensus_dt)
+  rm(consensus_df)
   gc()
   
   # get list of celltypes to keep and assign colors 
   celltype_groups <- group_stats_df |> 
-    dplyr::pull(broad_celltype_group) |> 
+    pull(broad_celltype_group) |> 
     unique() |>
     as.character()
   
   # filter markers to those that are actually relevant 
   # we will only plot the marker genes for cell types that are part of the assigned broad validation group for this group of samples
   # we don't care about plotting marker genes for cell types that aren't present here 
-  filtered_markers_df <- markers_dt |> 
-    dplyr::filter(validation_group_annotation %in% celltype_groups,
+  filtered_markers_df <- markers_df |> 
+    filter(validation_group_annotation %in% celltype_groups,
                   gene_symbol %in% group_stats_df$gene_symbol)
 
   # specify x axis order for dotplot
   marker_gene_order <- filtered_markers_df |> 
-    dplyr::pull(gene_symbol)
+    pull(gene_symbol)
   
   # set order for cell types 
   celltype_order <- unique(filtered_markers_df$validation_group_annotation)
   
   # filter out low expressed genes
   dotplot_df <- group_stats_df |> 
-    dplyr::filter(mean_exp > 0, percent_exp > 10) |> 
-    dplyr::arrange(broad_celltype_group) |> 
+    filter(mean_exp > 0, percent_exp > 10) |> 
+    arrange(broad_celltype_group) |> 
     # add a label for the plot 
-    dplyr::mutate(y_label = as.factor(glue::glue("{broad_celltype_group} ({total_cells})"))) |> 
+    mutate(y_label = as.factor(glue::glue("{broad_celltype_group} ({total_cells})"))) |> 
     # remove marker genes that aren't present in final annotations and set x axis order 
-    dplyr::filter(gene_symbol %in% marker_gene_order) |> 
-    dplyr::mutate(
+    filter(gene_symbol %in% marker_gene_order) |> 
+    mutate(
       # set orders of gene symbol and validation groups 
       gene_symbol = factor(gene_symbol, levels = marker_gene_order),
       validation_group_annotation = factor(validation_group_annotation, levels = celltype_order)
-    )
+    ) |>
+    as_tibble()
   
   
   # make dotplot with marker gene exp

--- a/scripts/utils/consensus-celltype-plotting-functions.R
+++ b/scripts/utils/consensus-celltype-plotting-functions.R
@@ -45,23 +45,11 @@ marker_gene_dotplot <- function(
   validation_groups_df <- as_tibble(validation_groups_df) |> as_duckdb_tibble()
   markers_df <- as_tibble(markers_df) |> as_duckdb_tibble()
 
-  # read in files
-  consensus_df <- celltype_files |>
-    purrr::map(fread) |>
-    data.table::rbindlist(fill = TRUE, use.names = TRUE) |>
-    as_duckdb_tibble(prudence = "thrifty")
+  # read in files directly to duckdb tables
+  # specify all varchar for consensus to avoid parsing error
+  consensus_df <- read_csv_duckdb(celltype_files, options = list(sep = "\t", union_by_name = TRUE)) 
 
-
-  # use a tempfile and read_csv_duckdb() to reduce memory usage for reading in gene expression files
-  gene_exp_csv <- tempfile(fileext = ".csv")
-  on.exit(unlink(gene_exp_csv), add = TRUE)
-  csv_append <- FALSE
-  for (f in gene_exp_files) {
-    gene_exp_df <- fread(f)
-    fwrite(gene_exp_df, gene_exp_csv, append = csv_append)
-    csv_append <- TRUE # after the first, append
-  }
-  gene_exp_df <- read_csv_duckdb(gene_exp_csv) |>
+  gene_exp_df <- read_csv_duckdb(gene_exp_files, options = list(sep = "\t", union_by_name = TRUE)) |>
     mutate(detected = logcounts > 0)
 
   # Join all consensus results and marker gene info


### PR DESCRIPTION
I had some time today, and I couldn't resist trying out `duckplyr`.

I think it works!

I converted most everything back from using `data.table` and `fread` to data frames in the main function, then convert everything to `duckdb_tibble` within the `marker_gene_dotplot` function.

To make it all work, I had to get rid of the `group_by()` statements, converting them to use the new `.by = ` syntax for `mutate()` and `summarize()`. 

~~That was enough to make it work, but reading in all of the gene expression files was still taking a lot of memory. To avoid that, I make a temporary csv file, and read that directly with `read_csv_duckdb()`. This worked amazingly well, and now it takes very little memory, even for Leukemia.
I would have done the same for the initial `consensus_df` tables, but those don't seem to always have the same columns? The gene expression table is the big one though, so it wasn't a big deal.~~

Update: I realized that the `read_csv_duckdb()` function is just fine with multiple files, even zipped, and can handle tsvs by specifying the separator. Even mismatched columns can be handled with the `union_by_name` option. So now this is even simpler!

You will probably want to look at this with whitespace off, as I did run it through `styler`, which made a number of formatting changes.

I didn't include the pdfs that were generated; they look the same to me, but are apparently slightly different at a binary level. But as a preview, here is the (underwhelming but reasonable?) leukemia plot, generated with <4GB memory.

<img width="1433" alt="Screenshot 2025-03-08 at 1 17 21 PM" src="https://github.com/user-attachments/assets/32f23303-36e3-4188-8128-53d5fecaef09" />

(Looks like we need to adjust ordering to match?)
