### PR TITLE
Update the gene set script

### DIFF
--- a/analysis/pseudobulk-bulk-prediction/scripts/prepare-ora-gene-sets.R
+++ b/analysis/pseudobulk-bulk-prediction/scripts/prepare-ora-gene-sets.R
@@ -124,7 +124,8 @@ consensus_cell_types <- consensus_ref_df |>
   dplyr::select(consensus_annotation, original_panglao_name) |>
   dplyr::distinct()
 
-# Create the consensus gene sets 
+# For each consensus group, determine the (unique) panglao marker genes that fed into it.
+# This creates a table with columns `cell_type_name`, `ensembl_id`, and `observed_in_singlecell`
 consensus_genesets_df <- split(consensus_cell_types, consensus_cell_types$consensus_annotation) |>
   purrr::map(
     \(df) {

--- a/analysis/pseudobulk-bulk-prediction/scripts/prepare-ora-gene-sets.R
+++ b/analysis/pseudobulk-bulk-prediction/scripts/prepare-ora-gene-sets.R
@@ -1,8 +1,10 @@
 # This script prepares gene sets for input to over-representation analysis (ORA) for a given ScPCA project as follows:
-# 1. Identify all unique consensus cell types across the project 
+# 
+# 1. Identify all possible consensus cell types which _could_ have been called for the project
 # 2. Identify the PanglaoDB cell types that contributed to those consensus labels
 # 3. Using the scpca-nf PanglaoDB cell type reference for the given project, determine the genes in those PanglaoDB cell types
 # 4. These (unique) genes define the gene set for a given consensus cell type to test in ORA
+# 5. We include an indicator column `observed_in_singlecell` for whether the given gene set was observed in the project's consensus cell types 
 
 
 renv::load()
@@ -92,11 +94,9 @@ keep_libraries <- library_metadata |>
   dplyr::pull(scpca_library_id) |>
   unique()
 
-
-# Find consensus cell type files for this project ---------------
-
-# nb, "Unknown" will still be included here, but it won't make it through the rest of the code
-present_celltypes <- celltype_files |>
+# Find all the _observed_ consensus cell type files for this project
+# we can use these to add an indicator to the final gene set list
+observed_celltypes <- celltype_files |>
   # only keep relevant libraries
   purrr::keep_at(
     \(library_id) library_id %in% keep_libraries
@@ -105,20 +105,27 @@ present_celltypes <- celltype_files |>
     \(f) {
       readr::read_tsv(f) |>
         dplyr::pull(consensus_annotation) 
-  }) |>
+    }) |>
   purrr::reduce(c) |>
   unique()
+observed_celltypes <- observed_celltypes[observed_celltypes != "Unknown"]
 
-# Combine these annotations with the consensus map to get their
-# original panglao names
-consenus_panglao_df <- consensus_ref_df |>
-  dplyr::filter(consensus_annotation %in% present_celltypes) |>
+
+# Determine consensus gene sets -------------------
+
+# Find all panglao cell types in the Panglao reference
+panglao_celltypes <- unique(panglao_df$panglao_celltype)
+panglao_celltypes <- panglao_celltypes[panglao_celltypes != "other"]
+
+
+# Determine the consensus cell types they contribute to
+consensus_cell_types <- consensus_ref_df |>
+  dplyr::filter(original_panglao_name %in% panglao_celltypes) |>
   dplyr::select(consensus_annotation, original_panglao_name) |>
-  dplyr::distinct() 
+  dplyr::distinct()
 
-# For each consensus group, determine the (unique) panglao marker genes that fed into it.
-# This creates a table with columns `cell_type_name` and `ensembl_id`
-consensus_genesets_df <- split(consenus_panglao_df, consenus_panglao_df$consensus_annotation) |>
+# Create the consensus gene sets 
+consensus_genesets_df <- split(consensus_cell_types, consensus_cell_types$consensus_annotation) |>
   purrr::map(
     \(df) {
       panglao_df |>
@@ -131,7 +138,10 @@ consensus_genesets_df <- split(consenus_panglao_df, consenus_panglao_df$consensu
     }
   ) |>
   # Convert to TSV for human-readable export
-  purrr::list_rbind(names_to = "cell_type_name")
+  purrr::list_rbind(names_to = "cell_type_name") |>
+  # Now, add an indicator column for whether the gene set (cell type) was observed
+  dplyr::mutate(observed_in_singlecell = cell_type_name %in% observed_celltypes)
+
 
 
 # Export tsv file ------------------------------


### PR DESCRIPTION
Closes #189 
Stacked on #196 

This PR updates the script to prepare gene sets for ORA. Previously, we considered only those consensus cell types which were actually observed in the single-cell data. Now, we'd like to potentially consider all consensus cell types which _could be_ observed. The previous approach is therefore a _subset_ of this new approach.

Therefore, I updated the script to collect all possible consensus cell type gene sets, and then I add an indicator column for whether that gene set was indeed observed in the consensus labels. The TSV files now contain three columns: `cell_type_name`, `ensembl_id`, and the new column `observed_in_singlecell` which is T/F. 

One question I have is, these gene set files are currently in `data` which is ignored by git, but these files (as well as some other TSV files in there) are indeed small enough to be under version control. Do we want to override the ignore for these TSVs? Or, might we want to save these TSVs elsewhere like results?

Either way for assistance in review, here are the gene set files I have generated here. 
[geneset_files.zip](https://github.com/user-attachments/files/19169656/geneset_files.zip)
