### PR TITLE
Filter to only samples used in analysis

### DIFF
--- a/analysis/pseudobulk-bulk-prediction/run-prediction.sh
+++ b/analysis/pseudobulk-bulk-prediction/run-prediction.sh
@@ -43,6 +43,7 @@ mkdir -p $ora_html_dir
 consensus_celltype_dir="../../s3_files/cell-type-consensus-results"
 
 # This convenience file keeps track of the bulk library & sample ids used
+# This is also used to assist filtering to single-cell processed RDS files of interest based on sample
 map_file="${data_dir}/bulk-library-sample-ids.tsv"
 
 
@@ -70,6 +71,7 @@ for project_dir in $scpca_dir/*; do
     # Calculate pseudobulk matrices for each project
     Rscript ${script_dir}/calculate-pseudobulk.R \
       --input_dir "${scpca_dir}/${project_id}" \
+      --map_file "${map_file}" \
       --output_pseudobulk_file "${pseudobulk_file}" \
       --output_frac_expressed_file "${fraction_expressed_file}"
 

--- a/analysis/pseudobulk-bulk-prediction/scripts/calculate-pseudobulk.R
+++ b/analysis/pseudobulk-bulk-prediction/scripts/calculate-pseudobulk.R
@@ -21,6 +21,11 @@ option_list <- list(
     help = "Input directory containing all _processed.rds files, which will be found recursively"
   ),
   make_option(
+    "--map_file", 
+    type = "character", 
+    help = "Path to TSV which contains samples used in analysis, which will be used to determine which processed RDS files to use."
+  ),
+  make_option(
     "--output_pseudobulk_file",
     type = "character",
     help = "Path to output TSV to save pseudobulk calculations"
@@ -36,35 +41,44 @@ opts <- parse_args(OptionParser(option_list = option_list))
 # Check inputs and paths -------
 stopifnot(
   "An input directory must be provided to `input_dir`." = !is.null(opts$input_dir),
-  "A path to an output TSV file to save pseudobulk counts must be specified with `output_pseudoulk_file`." = !is.null(opts$output_pseudobulk_file),
+  "A map file must be provided to `map_file`." = !is.null(opts$map_file),
+  "A path to an output TSV file to save pseudobulk counts must be specified with `output_pseudobulk_file`." = !is.null(opts$output_pseudobulk_file),
   "A path to an output TSV file to save fraction of single-cell samples genes are expressed in must be specified with `output_frac_expressed_file`." = !is.null(opts$output_frac_expressed_file)
 )
 fs::dir_create(dirname(opts$output_pseudobulk_file))
 fs::dir_create(dirname(opts$output_frac_expressed_file))
 
 
-# Read in all SCEs----------------
+# Prepare SCEs for calculations ----------------
 rds_files <- list.files(
   path = opts$input_dir,
   pattern = "_processed\\.rds$",
   recursive = TRUE
-)
+) |>
+  purrr::set_names(
+    \(f){stringr::str_split_i(f, pattern = "/", i = 1)}
+  )
 stopifnot(
   "Could not find any _processed.rds files in the provided `input_dir`." = length(rds_files) > 0
 )
 
-sample_ids <- stringr::str_split_i(rds_files, pattern = "/", i = 1)
-rds_files <- file.path(opts$input_dir, rds_files) # update to contain full path
-names(rds_files) <- sample_ids
+# Read in map file for subsetting SCEs
+map_df <- readr::read_tsv(opts$map_file)
 
-sce_list <- purrr::map(rds_files, readr::read_rds)
+# consider only sample ids included in analysis
+rds_files <- rds_files[names(rds_files) %in% map_df$scpca_sample_id]
+
+sce_list <- rds_files |>
+  purrr::map(
+    \(f) {
+      readr::read_rds(file.path(opts$input_dir, f))
+  })
 
 # extract and sum the raw counts
 pseudo_raw_counts <- sce_list |>
   purrr::map(counts) |>
   purrr::map(rowSums) |>
   do.call(cbind, args = _ )
-
 
 # Export table of fraction expressed based on raw counts alone
 rowMeans(pseudo_raw_counts > 0) |>
@@ -78,7 +92,7 @@ pseudo_deseq <- DESeqDataSetFromMatrix(
   countData = pseudo_raw_counts,
   # these arguments don't matter for our purposes,
   # but DESeq2 requires them
-  colData = data.frame(sample = sample_ids),
+  colData = data.frame(sample = names(rds_files)),
   design = ~sample) |>
   estimateSizeFactors() |>
   rlog(blind = TRUE) |>


### PR DESCRIPTION
Closes #241 

The overall goal of these changes is to update code to _not assume_ that all libraries present should be used in analysis. This is because, when others download portal data to reproduce, they should be able to keep all the samples from the portal without having to worry which are actually used in the bulk analysis.

Implementing this turned out to be simpler than I expected! We already have a tsv file with bulk libraries & samples that are used in analysis, so we can use those sample ids to filter down to single-cell/nuclei samples of interest too. The only place this needed to happen was in the script that calculates pseudobulk. After this stage, the scpca data files are no longer used in the code. I added this map file as an input argument to the script and use it to subset samples before doing pseudobulk calculations.

I tested this out by downloading `SCPCP000009` (full of unused multiplexed!) from the portal and ran the script with that as the data input directory. When I ran the code, the resulting pseudobulk tsv only contained the 4 (non-multiplexed) samples we use for this analysis, so it's working as expected!