### PR TITLE
Sync the panglao references

### DIFF
--- a/reproduce-figures/prepare-scpca-portal-data.R
+++ b/reproduce-figures/prepare-scpca-portal-data.R
@@ -9,11 +9,11 @@
 #
 #####################################################################################
 ### CAUTION! YOU WILL NEED AT LEAST 170 GB OF AVAILABLE SPACE TO RUN THIS SCRIPT. ###
-##################################################################################### 
+#####################################################################################
 #
 #
 # ########################### Instructions ############################
-# 
+#
 # Before running this script, you will need to take the following steps:
 #
 # 1. Ensure you have set up the `renv` environment in this project.
@@ -29,12 +29,12 @@
 #    Optionally, you can also store the merged version of SCPCP000003 and the portal metadata TSV in this directory, but it is not necessary.
 
 # Then, you can run this script as follows:
-# 
+#
 #   Rscript prepare-scpca-portal-data.R \
 #     --portal_projects_dir <path to directory with all project zip files> \
 #     --merged_sce_path <path to merged SCE file> \
 #     --portal_metadata_path <path to portal-wide metadata TSV>
-# 
+#
 # By default, the output directories will be saved in the location in this repository where code expects them:
 # - `s3_files/` will be placed in the top level of the `scpca-paper-figures` repository
 # - `scpca-data/` will be placed inside the bulk analysis data directory, `scpca-paper-figures/pseudobulk-bulk-prediction/data/`
@@ -70,19 +70,19 @@ option_list <- list(
   make_option(
     "--s3_files_dir",
     type = "character",
-    default = here::here("s3_files"), 
+    default = here::here("s3_files"),
     help = "Output directory for `s3_files`. Default is in the top-level of the repository, which is where code expects it to be."
   ),
   make_option(
     "--bulk_data_dir",
     type = "character",
-    default = here::here("analysis", "pseudobulk-bulk-prediction", "data", "scpca-data"), 
+    default = here::here("analysis", "pseudobulk-bulk-prediction", "data", "scpca-data"),
     help = "Output directory for data used in the bulk RNA-Seq analysis. Default is `analysis/pseudobulk-bulk-prediction/data/scpca-data`, which is where code expects it to be."
-  ),  
+  ),
   make_option(
-     "--scratch_dir", 
-    type = "character", 
-    default = here::here("reproduce-figures", "scratch"), 
+     "--scratch_dir",
+    type = "character",
+    default = here::here("reproduce-figures", "scratch"),
     help = "Scratch directory for holding temporary files during processing"
   ),
   make_option(
@@ -94,7 +94,7 @@ option_list <- list(
   make_option(
     "--project_whitelist",
     type = "character",
-    default = here::here("sample-info", "project-whitelist.txt"), 
+    default = here::here("sample-info", "project-whitelist.txt"),
     help = "Path to file containing all projects considered in the manuscript."
   )
 )
@@ -111,12 +111,12 @@ source(utils_file)
 
 # Check files and directories - for user-provided, first if they were specified, then if they exist
 stopifnot(
-  "Path to directory with project ZIP files be specified with --portal_projects_dir" = !is.null(opts$portal_projects_dir), 
+  "Path to directory with project ZIP files be specified with --portal_projects_dir" = !is.null(opts$portal_projects_dir),
   "Path to merged SCE for project SCPCP000003 must be specified with --merged_sce_path" = !is.null(opts$merged_sce_path),
   "Portal-wide metadata TSV must be specified with --portal_metadata_path" = !is.null(opts$portal_metadata_path)
 )
 stopifnot(
-  "Portal projects directory not found" = dir.exists(opts$portal_projects_dir), 
+  "Portal projects directory not found" = dir.exists(opts$portal_projects_dir),
   "Merged SCE for project SCPCP000003 not found" = file.exists(opts$merged_sce_path),
   "Portal-wide metadata TSV not found" = file.exists(opts$portal_metadata_path),
   "Project whitelist could not be found" = file.exists(opts$project_whitelist)
@@ -133,16 +133,18 @@ if ((dir.exists(opts$s3_files_dir) | dir.exists(opts$bulk_data_dir))) {
 }
 
 # Define and create directories
-consensus_files_dir <- file.path(opts$s3_files_dir, "cell-type-consensus-results")
-celltype_results_dir <- file.path(opts$s3_files_dir, "celltype_results")
-reference_dir <- file.path(opts$s3_files_dir, "reference_files")
+consensus_files_dir   <- file.path(opts$s3_files_dir, "cell-type-consensus-results")
+celltype_results_dir  <- file.path(opts$s3_files_dir, "celltype_results")
+s3_files_reference_dir <- file.path(opts$s3_files_dir, "reference_files")
+bulk_reference_dir    <- file.path(opts$bulk_data_dir, "references")
 
 fs::dir_create(c(
   opts$scratch_dir,
   opts$bulk_data_dir,
-  consensus_files_dir, 
-  celltype_results_dir, 
-  reference_dir
+  consensus_files_dir,
+  celltype_results_dir,
+  s3_files_reference_dir,
+  bulk_reference_dir
 ))
 
 # Define marker genes for recreating expression matrices used for consensus cell type dot plots
@@ -154,32 +156,32 @@ marker_genes <- readr::read_tsv(marker_gene_ref_file) |>
 ### Some need just processed, and some also need (un)filtered, but scripts specify which one
 ### We can therefore retain all RDS files when copying; extra files will not be used either way
 standalone_sample_dirs <- c(
-  "SCPCS000001", 
-  "SCPCS000216", 
-  "SCPCS000251", 
+  "SCPCS000001",
+  "SCPCS000216",
+  "SCPCS000251",
   "SCPCS000264"
 )
 
 # These samples' processed.rds files should be saved to celltype_results_dir
 celltype_results_samples <- c(
   "SCPCS000001",
-  "SCPCS000002", 
-  "SCPCS000004", 
-  "SCPCS000252", 
+  "SCPCS000002",
+  "SCPCS000004",
+  "SCPCS000252",
   "SCPCS000258",
-  "SCPCS000262", 
-  "SCPCS000222", 
-  "SCPCS000223", 
+  "SCPCS000262",
+  "SCPCS000222",
+  "SCPCS000223",
   "SCPCS000224"
 )
 
 # These are the directories to save to opts$bulk_files_dir
 # They should contain processed files organized as expected and the bulk quant TSV file
 bulk_projects <- c(
-  "SCPCP000001", 
-  "SCPCP000002", 
-  "SCPCP000006", 
-  "SCPCP000009", 
+  "SCPCP000001",
+  "SCPCP000002",
+  "SCPCP000006",
+  "SCPCP000009",
   "SCPCP000017"
 )
 
@@ -191,10 +193,10 @@ expected_projects <- readLines(opts$project_whitelist)
 
 # Define and check input projects
 input_zips <- list.files(
-  opts$portal_projects_dir, 
+  opts$portal_projects_dir,
   # allow for a token after .zip
   pattern = "^SCPCP\\d{6}_single-cell.+\\.zip\\?*.*",
-  full.names = TRUE, 
+  full.names = TRUE,
   ignore.case = TRUE # case insensitive regex
 ) |>
   # remove any merged objects
@@ -204,7 +206,7 @@ input_zips <- list.files(
     \(x) {stringr::str_split_i(basename(x), "_", 1)}
   )
 stopifnot(
-  "The provided input directory does not contain all expected projects. Zip files for all projects listed in the `project-whitelist.txt` file should be present." = 
+  "The provided input directory does not contain all expected projects. Zip files for all projects listed in the `project-whitelist.txt` file should be present." =
     setequal(names(input_zips), expected_projects)
 )
 
@@ -215,7 +217,7 @@ fs::dir_create(c(merged_sce_dir, merge_scratch_dir))
 
 unzip(opts$merged_sce_path, exdir = merge_scratch_dir)
 fs::file_move(
-  file.path(merge_scratch_dir, "SCPCP000003_merged.rds"), 
+  file.path(merge_scratch_dir, "SCPCP000003_merged.rds"),
   merged_sce_dir
 )
 
@@ -226,43 +228,43 @@ fs::dir_delete(merge_scratch_dir)
 input_zips |>
   purrr::iwalk(
     \(project_zip, project_id){
-      
+
       # scratch directory to store unzipped files during processing
-      project_scratch_dir <- file.path(opts$scratch_dir, project_id) 
+      project_scratch_dir <- file.path(opts$scratch_dir, project_id)
       fs::dir_create(project_scratch_dir)
-      
+
       # Unzip the directory to scratch
       unzip(project_zip, exdir = project_scratch_dir)
 
       # Define all sample directories present in this project, _excluding_ multiplexed samples
       # This is because multiplexed samples aren't used in any figures created from ScPCA data files
       sample_dirs <- list.dirs(
-        project_scratch_dir, 
+        project_scratch_dir,
         full.names = TRUE
       ) |>
         purrr::set_names(\(x) {basename(x)}) |>
         # get rid of itself & multiplexed samples
         purrr::discard_at(\(x) {stringr::str_detect(x, project_id)}) |>
-        purrr::discard_at(\(x) {stringr::str_detect(x, "_")}) 
+        purrr::discard_at(\(x) {stringr::str_detect(x, "_")})
 
       ####### Step 1: Copy RDS files to target directories #######
       sample_dirs |>
         purrr::iwalk(
           \(sample_dir, sample_id) {
-            
+
             # Copy processed rds files to celltype_results_files
             # The next step will parse these files into TSVs
             if (sample_id %in% celltype_results_samples) {
               system(glue::glue("cp {sample_dir}/*processed.rds {celltype_results_dir}"))
-            } 
-            
+            }
+
             # Copy rds files to standalone sample dir
             if (sample_id %in% standalone_sample_dirs) {
               standalone_dir <- file.path(opts$s3_files_dir, sample_id)
               fs::dir_create(standalone_dir)
               system(glue::glue("cp -r {sample_dir}/*rds {standalone_dir}"))
-            } 
-            
+            }
+
       })
 
       # If this project is used in the bulk analysis, copy to bulk_project_dir
@@ -270,27 +272,27 @@ input_zips |>
         # First, we'll remove the files that aren't needed to save disk space
         system(glue::glue("rm {project_scratch_dir}/*/*filtered.rds"))
         system(glue::glue("rm {project_scratch_dir}/*/*html"))
-        
+
         fs::dir_copy(project_scratch_dir, opts$bulk_data_dir)
       }
-      
+
       ####### Step 2: Prepare consensus cell type files #######
       sample_dirs |>
         purrr::iwalk(
           \(sample_dir, sample_id) {
-              
+
             # Map over all rds files for each sample
             list.files(
               path = sample_dir,
-              pattern = "_processed\\.rds$", 
+              pattern = "_processed\\.rds$",
               full.names = TRUE
             ) |>
               purrr::walk(\(rds) {
-                  
+
                 # Define output file paths
-                outdir <- file.path(consensus_files_dir, project_id, sample_id) 
+                outdir <- file.path(consensus_files_dir, project_id, sample_id)
                 fs::dir_create(outdir)
-                
+
                 output_consensus_tsv <- file.path(
                   outdir,
                   stringr::str_replace(basename(rds), "_processed\\.rds$", "_processed_consensus-cell-types.tsv.gz")
@@ -299,19 +301,19 @@ input_zips |>
                   outdir,
                   stringr::str_replace(basename(rds), "_processed\\.rds$", "_processed_marker-gene-expression.tsv.gz")
                 )
-                  
-                # Read in the SCE 
+
+                # Read in the SCE
                 sce <- readRDS(rds)
-                  
+
                 # Prepare and export consensus tsv
                 prepare_consensus_tsv(sce, output_consensus_tsv)
-                  
+
                 # Prepare and export marker gene expression tsv
                 prepare_gene_expression_tsv(sce, marker_genes, output_gene_expr_tsv)
-                  
-            })  
+
+            })
       })
-      
+
       # Now that this project has been processed, we can clean out the scratch directory
       fs::dir_delete(project_scratch_dir)
 })
@@ -341,14 +343,24 @@ library_metadata <- portal_metadata |>
 
 # annotation files
 system(
-  glue::glue("aws s3 cp s3://scpca-references/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.spliced_cdna.tx2gene.tsv {reference_dir} --no-sign-request")
+  glue::glue("aws s3 cp s3://scpca-references/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.spliced_cdna.tx2gene.tsv {s3_files_reference_dir} --no-sign-request")
 )
 system(
-  glue::glue("aws s3 cp s3://scpca-references/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.mitogenes.txt {reference_dir} --no-sign-request")
+  glue::glue("aws s3 cp s3://scpca-references/homo_sapiens/ensembl-104/annotation/Homo_sapiens.GRCh38.104.mitogenes.txt {s3_files_reference_dir} --no-sign-request")
 )
 
 # SingleR model files
 system(
-  glue::glue("aws s3 cp s3://scpca-references/celltype/singler_models/ {reference_dir} --recursive --exclude '*' --include '*.rds' --no-sign-request")
+  glue::glue("aws s3 cp s3://scpca-references/celltype/singler_models/ {s3_files_reference_dir} --recursive --exclude '*' --include '*.rds' --no-sign-request")
 )
 
+# Panglao marker gene references
+system(
+  glue::glue("aws s3 cp s3://scpca-references/celltype/cellassign_references/bone-and-soft-tissue_PanglaoDB_2020-03-27.tsv {bulk_reference_dir} --no-sign-request")
+)
+system(
+  glue::glue("aws s3 cp s3://scpca-references/celltype/cellassign_references/brain-compartment_PanglaoDB_2020-03-27.tsv {bulk_reference_dir} --no-sign-request")
+)
+system(
+  glue::glue("aws s3 cp s3://scpca-references/celltype/cellassign_references/kidney-compartment_PanglaoDB_2020-03-27.tsv {bulk_reference_dir} --no-sign-request")
+)


### PR DESCRIPTION
I started working on (edit, wrong link) #211 & #245, beginning with running the code all the way through. So, I found the first and hopefully last set of files we still need to grab - the panglao/cellassign marker gene references used in bulk analysis to make the gene sets. 

This PR adds that step to the data prep script. In addition,  I renamed the existing `reference_dir` variable so we can distinguish between s3_files vs bulk reference directories. I did make this change in VS Code, which ate up many spaces, so I recommend turning off whitespace!