### PR TITLE
Account for SCEs without consensus cell types

### DIFF
--- a/reproduce-figures/prepare-scpca-portal-data.R
+++ b/reproduce-figures/prepare-scpca-portal-data.R
@@ -58,14 +58,14 @@ option_list <- list(
     help = "Path to directory containing project ZIP files downloaded from the ScPCA Portal"
   ),
   make_option(
-    "--portal_metadata_path",
-    type = "character",
-    help = "Path to the the portal-wide metadata TSV"
-  ),
-  make_option(
     "--merged_sce_path",
     type = "character",
     help = "Path to the merged SCPCP000003 project ZIP file"
+  ),
+  make_option(
+    "--portal_metadata_path",
+    type = "character",
+    help = "Path to the the portal-wide metadata TSV"
   ),
   make_option(
     "--s3_files_dir",
@@ -266,6 +266,7 @@ input_zips |>
       })
 
       # If this project is used in the bulk analysis, copy to bulk_project_dir
+      # We do this after copying samples above since we don't want to remove their (un)filtered files
       if (project_id %in% bulk_projects) {
         # First, we'll remove the files that aren't needed to save disk space
         system(glue::glue("rm {project_scratch_dir}/*/*filtered.rds"))

--- a/reproduce-figures/prepare-scpca-portal-data.R
+++ b/reproduce-figures/prepare-scpca-portal-data.R
@@ -3,17 +3,17 @@
 # This script organizes and parses data obtained from the ScPCA Portal so that figures and analyses can be reproduced.
 # This script will create two directories you'll need:
 # - `s3_files`: This directory will contain ScPCA data files needed to reproduce tables and figures.
-# - `scpca-data`: This directory will contain ScPCA data files needed to reproduce the bulk expression analysis.
+# - `scpca_data`: This directory will contain ScPCA data files needed to reproduce the bulk expression analysis.
 #
 # For full details and instructions, please refer to the current directory's `README.md`.
 #
 #####################################################################################
 ### CAUTION! YOU WILL NEED AT LEAST 170 GB OF AVAILABLE SPACE TO RUN THIS SCRIPT. ###
-##################################################################################### 
+#####################################################################################
 #
 #
 # ########################### Instructions ############################
-# 
+#
 # Before running this script, you will need to take the following steps:
 #
 # 1. Ensure you have set up the `renv` environment in this project.
@@ -29,15 +29,15 @@
 #    Optionally, you can also store the merged version of SCPCP000003 and the portal metadata TSV in this directory, but it is not necessary.
 
 # Then, you can run this script as follows:
-# 
+#
 #   Rscript prepare-scpca-portal-data.R \
 #     --portal_projects_dir <path to directory with all project zip files> \
 #     --merged_sce_path <path to merged SCE file> \
 #     --portal_metadata_path <path to portal-wide metadata TSV>
-# 
+#
 # By default, the output directories will be saved in the location in this repository where code expects them:
 # - `s3_files/` will be placed in the top level of the `scpca-paper-figures` repository
-# - `scpca-data/` will be placed inside the bulk analysis data directory, `scpca-paper-figures/pseudobulk-bulk-prediction/data/`
+# - `scpca_data/` will be placed inside the bulk analysis data directory, `scpca-paper-figures/pseudobulk-bulk-prediction/data/`
 # You can provide custom directories if you prefer; use the `--help` flag to see all script options.
 # Note that this script will not overwrite existing output directories without the `--overwrite` flag.
 
@@ -70,19 +70,19 @@ option_list <- list(
   make_option(
     "--s3_files_dir",
     type = "character",
-    default = here::here("s3_files"), 
+    default = here::here("s3_files"),
     help = "Output directory for `s3_files`. Default is in the top-level of the repository, which is where code expects it to be."
   ),
   make_option(
     "--bulk_data_dir",
     type = "character",
-    default = here::here("analysis", "pseudobulk-bulk-prediction", "data", "scpca-data"), 
-    help = "Output directory for data used in the bulk RNA-Seq analysis. Default is `analysis/pseudobulk-bulk-prediction/data/scpca-data`, which is where code expects it to be."
-  ),  
+    default = here::here("analysis", "pseudobulk-bulk-prediction", "data", "scpca_data"),
+    help = "Output directory for data used in the bulk RNA-Seq analysis. Default is `analysis/pseudobulk-bulk-prediction/data/scpca_data`, which is where code expects it to be."
+  ),
   make_option(
-     "--scratch_dir", 
-    type = "character", 
-    default = here::here("reproduce-figures", "scratch"), 
+     "--scratch_dir",
+    type = "character",
+    default = here::here("reproduce-figures", "scratch"),
     help = "Scratch directory for holding temporary files during processing"
   ),
   make_option(
@@ -94,7 +94,7 @@ option_list <- list(
   make_option(
     "--project_whitelist",
     type = "character",
-    default = here::here("sample-info", "project-whitelist.txt"), 
+    default = here::here("sample-info", "project-whitelist.txt"),
     help = "Path to file containing all projects considered in the manuscript."
   )
 )
@@ -111,12 +111,12 @@ source(utils_file)
 
 # Check files and directories - for user-provided, first if they were specified, then if they exist
 stopifnot(
-  "Path to directory with project ZIP files be specified with --portal_projects_dir" = !is.null(opts$portal_projects_dir), 
+  "Path to directory with project ZIP files be specified with --portal_projects_dir" = !is.null(opts$portal_projects_dir),
   "Path to merged SCE for project SCPCP000003 must be specified with --merged_sce_path" = !is.null(opts$merged_sce_path),
   "Portal-wide metadata TSV must be specified with --portal_metadata_path" = !is.null(opts$portal_metadata_path)
 )
 stopifnot(
-  "Portal projects directory not found" = dir.exists(opts$portal_projects_dir), 
+  "Portal projects directory not found" = dir.exists(opts$portal_projects_dir),
   "Merged SCE for project SCPCP000003 not found" = file.exists(opts$merged_sce_path),
   "Portal-wide metadata TSV not found" = file.exists(opts$portal_metadata_path),
   "Project whitelist could not be found" = file.exists(opts$project_whitelist)
@@ -140,8 +140,8 @@ reference_dir <- file.path(opts$s3_files_dir, "reference_files")
 fs::dir_create(c(
   opts$scratch_dir,
   opts$bulk_data_dir,
-  consensus_files_dir, 
-  celltype_results_dir, 
+  consensus_files_dir,
+  celltype_results_dir,
   reference_dir
 ))
 
@@ -154,32 +154,32 @@ marker_genes <- readr::read_tsv(marker_gene_ref_file) |>
 ### Some need just processed, and some also need (un)filtered, but scripts specify which one
 ### We can therefore retain all RDS files when copying; extra files will not be used either way
 standalone_sample_dirs <- c(
-  "SCPCS000001", 
-  "SCPCS000216", 
-  "SCPCS000251", 
+  "SCPCS000001",
+  "SCPCS000216",
+  "SCPCS000251",
   "SCPCS000264"
 )
 
 # These samples' processed.rds files should be saved to celltype_results_dir
 celltype_results_samples <- c(
   "SCPCS000001",
-  "SCPCS000002", 
-  "SCPCS000004", 
-  "SCPCS000252", 
+  "SCPCS000002",
+  "SCPCS000004",
+  "SCPCS000252",
   "SCPCS000258",
-  "SCPCS000262", 
-  "SCPCS000222", 
-  "SCPCS000223", 
+  "SCPCS000262",
+  "SCPCS000222",
+  "SCPCS000223",
   "SCPCS000224"
 )
 
 # These are the directories to save to opts$bulk_files_dir
 # They should contain processed files organized as expected and the bulk quant TSV file
 bulk_projects <- c(
-  "SCPCP000001", 
-  "SCPCP000002", 
-  "SCPCP000006", 
-  "SCPCP000009", 
+  "SCPCP000001",
+  "SCPCP000002",
+  "SCPCP000006",
+  "SCPCP000009",
   "SCPCP000017"
 )
 
@@ -191,10 +191,10 @@ expected_projects <- readLines(opts$project_whitelist)
 
 # Define and check input projects
 input_zips <- list.files(
-  opts$portal_projects_dir, 
+  opts$portal_projects_dir,
   # allow for a token after .zip
   pattern = "^SCPCP\\d{6}_single-cell.+\\.zip\\?*.*",
-  full.names = TRUE, 
+  full.names = TRUE,
   ignore.case = TRUE # case insensitive regex
 ) |>
   # remove any merged objects
@@ -204,7 +204,7 @@ input_zips <- list.files(
     \(x) {stringr::str_split_i(basename(x), "_", 1)}
   )
 stopifnot(
-  "The provided input directory does not contain all expected projects. Zip files for all projects listed in the `project-whitelist.txt` file should be present." = 
+  "The provided input directory does not contain all expected projects. Zip files for all projects listed in the `project-whitelist.txt` file should be present." =
     setequal(names(input_zips), expected_projects)
 )
 
@@ -215,7 +215,7 @@ fs::dir_create(c(merged_sce_dir, merge_scratch_dir))
 
 unzip(opts$merged_sce_path, exdir = merge_scratch_dir)
 fs::file_move(
-  file.path(merge_scratch_dir, "SCPCP000003_merged.rds"), 
+  file.path(merge_scratch_dir, "SCPCP000003_merged.rds"),
   merged_sce_dir
 )
 
@@ -226,43 +226,43 @@ fs::dir_delete(merge_scratch_dir)
 input_zips |>
   purrr::iwalk(
     \(project_zip, project_id){
-      
+
       # scratch directory to store unzipped files during processing
-      project_scratch_dir <- file.path(opts$scratch_dir, project_id) 
+      project_scratch_dir <- file.path(opts$scratch_dir, project_id)
       fs::dir_create(project_scratch_dir)
-      
+
       # Unzip the directory to scratch
       unzip(project_zip, exdir = project_scratch_dir)
 
       # Define all sample directories present in this project, _excluding_ multiplexed samples
       # This is because multiplexed samples aren't used in any figures created from ScPCA data files
       sample_dirs <- list.dirs(
-        project_scratch_dir, 
+        project_scratch_dir,
         full.names = TRUE
       ) |>
         purrr::set_names(\(x) {basename(x)}) |>
         # get rid of itself & multiplexed samples
         purrr::discard_at(\(x) {stringr::str_detect(x, project_id)}) |>
-        purrr::discard_at(\(x) {stringr::str_detect(x, "_")}) 
+        purrr::discard_at(\(x) {stringr::str_detect(x, "_")})
 
       ####### Step 1: Copy RDS files to target directories #######
       sample_dirs |>
         purrr::iwalk(
           \(sample_dir, sample_id) {
-            
+
             # Copy processed rds files to celltype_results_files
             # The next step will parse these files into TSVs
             if (sample_id %in% celltype_results_samples) {
               system(glue::glue("cp {sample_dir}/*processed.rds {celltype_results_dir}"))
-            } 
-            
+            }
+
             # Copy rds files to standalone sample dir
             if (sample_id %in% standalone_sample_dirs) {
               standalone_dir <- file.path(opts$s3_files_dir, sample_id)
               fs::dir_create(standalone_dir)
               system(glue::glue("cp -r {sample_dir}/*rds {standalone_dir}"))
-            } 
-            
+            }
+
       })
 
       # If this project is used in the bulk analysis, copy to bulk_project_dir
@@ -270,27 +270,27 @@ input_zips |>
         # First, we'll remove the files that aren't needed to save disk space
         system(glue::glue("rm {project_scratch_dir}/*/*filtered.rds"))
         system(glue::glue("rm {project_scratch_dir}/*/*html"))
-        
+
         fs::dir_copy(project_scratch_dir, opts$bulk_data_dir)
       }
-      
+
       ####### Step 2: Prepare consensus cell type files #######
       sample_dirs |>
         purrr::iwalk(
           \(sample_dir, sample_id) {
-              
+
             # Map over all rds files for each sample
             list.files(
               path = sample_dir,
-              pattern = "_processed\\.rds$", 
+              pattern = "_processed\\.rds$",
               full.names = TRUE
             ) |>
               purrr::walk(\(rds) {
-                  
+
                 # Define output file paths
-                outdir <- file.path(consensus_files_dir, project_id, sample_id) 
+                outdir <- file.path(consensus_files_dir, project_id, sample_id)
                 fs::dir_create(outdir)
-                
+
                 output_consensus_tsv <- file.path(
                   outdir,
                   stringr::str_replace(basename(rds), "_processed\\.rds$", "_processed_consensus-cell-types.tsv.gz")
@@ -299,19 +299,19 @@ input_zips |>
                   outdir,
                   stringr::str_replace(basename(rds), "_processed\\.rds$", "_processed_marker-gene-expression.tsv.gz")
                 )
-                  
-                # Read in the SCE 
+
+                # Read in the SCE
                 sce <- readRDS(rds)
-                  
+
                 # Prepare and export consensus tsv
                 prepare_consensus_tsv(sce, output_consensus_tsv)
-                  
+
                 # Prepare and export marker gene expression tsv
                 prepare_gene_expression_tsv(sce, marker_genes, output_gene_expr_tsv)
-                  
-            })  
+
+            })
       })
-      
+
       # Now that this project has been processed, we can clean out the scratch directory
       fs::dir_delete(project_scratch_dir)
 })

--- a/reproduce-figures/utils.R
+++ b/reproduce-figures/utils.R
@@ -11,6 +11,16 @@
 #'
 prepare_consensus_tsv <- function(sce, output_tsv){
   
+  # Define consensus cell types since they won't be present in SCEs which were not
+  #  annotated with both SingleR and CellAssign
+  if ("consensus_celltype_annotation" %in% names(colData(sce))) {
+    # TODO: This column needs to be updated
+    # See https://github.com/AlexsLemonade/scpca-paper-figures/issues/253
+    consensus_celltypes <- sce$singler_celltype_annotation
+  } else {
+    consensus_celltypes <- NA
+  }
+  
   # Prepare and export the consensus cell types table from sce contents
   data.frame(
     project_id = metadata(sce)$project_id, 
@@ -18,8 +28,7 @@ prepare_consensus_tsv <- function(sce, output_tsv){
     library_id = metadata(sce)$library_id, 
     sample_type = paste0(metadata(sce)$sample_type, collapse = ","),
     barcodes = colnames(sce), 
-    # TODO TEMPORARY TO TEST THE CODE!!!!!!!!!!!
-    consensus_annotation = sce$singler_celltype_annotation 
+    consensus_annotation = consensus_celltypes
   ) |>
     # export
     readr::write_tsv(output_tsv)


### PR DESCRIPTION
While testing code towards #211 & #245, I hit a bug in the consensus cell type functions at project SCPCP000020. This is a cell line project, so it didn't have the singler cell type column (which is temporarily coded up), but it certainly won't have a consensus annotation either! So, I updated this function to use `NA` values if the column isn't present. 

Additional small changes in the other script are present too:
- Fixed other small bug to change `scpca-data` to `scpca_data`
- I swapped an arg order to match the usage docs (makes it easier for me to work with code) and added a comment for future us.