### PR TITLE
Update metadata parsing

### DIFF
--- a/reproduce-figures/prepare-scpca-portal-data.R
+++ b/reproduce-figures/prepare-scpca-portal-data.R
@@ -327,7 +327,7 @@ input_zips |>
 # Read input metadata file
 portal_metadata <- readr::read_tsv(opts$portal_metadata_path)
 sample_metadata_file <- file.path(opts$s3_files_dir, "scpca-sample-metadata.tsv")
-library_metadata_file <- file.path(opts$s3_files_dir, "library-sample-metadata.tsv")
+library_metadata_file <- file.path(opts$s3_files_dir, "scpca-library-metadata.tsv")
 
 # Create and export sample metadata table
  portal_metadata |>

--- a/reproduce-figures/prepare-scpca-portal-data.R
+++ b/reproduce-figures/prepare-scpca-portal-data.R
@@ -9,6 +9,8 @@
 #
 #####################################################################################
 ### CAUTION! YOU WILL NEED AT LEAST 170 GB OF AVAILABLE SPACE TO RUN THIS SCRIPT. ###
+###                                                                               ###
+### In addition, it will take roughly 90 minutes to run this script.              ###
 #####################################################################################
 #
 #

--- a/reproduce-figures/prepare-scpca-portal-data.R
+++ b/reproduce-figures/prepare-scpca-portal-data.R
@@ -353,11 +353,11 @@ sample_metadata_file <- file.path(opts$s3_files_dir, "scpca-sample-metadata.tsv"
 library_metadata_file <- file.path(opts$s3_files_dir, "scpca-library-metadata.tsv")
 
 # Create and export sample metadata table
-portal_metadata |>
-  dplyr::select(scpca_project_id, scpca_sample_id, diagnosis, disease_timing, is_cell_line) |>
-  # remove duplicate rows, which occur when there are multiple libraries per sample
-  dplyr::distinct() |>
-  readr::write_tsv(sample_metadata_file)
+prepare_sample_metadata(
+  portal_metadata,
+  sample_metadata_file
+)
+
 
 # Create and export library metadata table
 prepare_library_metadata(

--- a/reproduce-figures/prepare-scpca-portal-data.R
+++ b/reproduce-figures/prepare-scpca-portal-data.R
@@ -138,7 +138,14 @@ if ((dir.exists(opts$s3_files_dir) | dir.exists(opts$bulk_data_dir))) {
 consensus_files_dir   <- file.path(opts$s3_files_dir, "cell-type-consensus-results")
 celltype_results_dir  <- file.path(opts$s3_files_dir, "celltype_results")
 s3_files_reference_dir <- file.path(opts$s3_files_dir, "reference_files")
+merged_sce_dir <- file.path(opts$s3_files_dir, "SCPCP000003")
 bulk_reference_dir    <- file.path(opts$bulk_data_dir, "references")
+
+# these directories are for temporary file stored in scratch
+merged_scratch_dir <- file.path(opts$scratch_dir, "SCPCP000003_merged")
+bulk_metadata_scratch_dir <- file.path(opts$scratch_dir, "bulk-metadata")
+citeseq_metadata_scratch_dir <- file.path(opts$scratch_dir, "citeseq-project-metadata")
+
 
 fs::dir_create(c(
   opts$scratch_dir,
@@ -146,7 +153,11 @@ fs::dir_create(c(
   consensus_files_dir,
   celltype_results_dir,
   s3_files_reference_dir,
-  bulk_reference_dir
+  merged_sce_dir,
+  bulk_reference_dir,
+  merged_scratch_dir,
+  bulk_metadata_scratch_dir,
+  citeseq_metadata_scratch_dir
 ))
 
 # Define marker genes for recreating expression matrices used for consensus cell type dot plots
@@ -187,6 +198,9 @@ bulk_projects <- c(
   "SCPCP000017"
 )
 
+# Projects with CITE-seq technology which we'll assign technology to when preparing metadata
+citeseq_projects <- c("SCPCP000003", "SCPCP000007", "SCPCP000008")
+
 
 # Define input files ------------------------
 
@@ -213,18 +227,13 @@ stopifnot(
 )
 
 # First, unzip and copy over the merged SCPCP000003 file -----------------------
-merged_sce_dir <- file.path(opts$s3_files_dir, "SCPCP000003")
-merge_scratch_dir <- file.path(opts$scratch_dir, "SCPCP000003_merged")
-fs::dir_create(c(merged_sce_dir, merge_scratch_dir))
-
-unzip(opts$merged_sce_path, exdir = merge_scratch_dir)
+unzip(opts$merged_sce_path, exdir = merged_scratch_dir)
 fs::file_move(
-  file.path(merge_scratch_dir, "SCPCP000003_merged.rds"),
+  file.path(merged_scratch_dir, "SCPCP000003_merged.rds"),
   merged_sce_dir
 )
-
-# clean up
-fs::dir_delete(merge_scratch_dir)
+# clean up for space
+fs::dir_delete(merged_scratch_dir)
 
 # Map over project zip files to organize files for reproducibility -------------
 input_zips |>
@@ -268,6 +277,20 @@ input_zips |>
             }
 
       })
+      
+      # Save metadata files to use when preparing the sample and library metadata files later
+      project_bulk_tsv <- file.path(project_scratch_dir, glue::glue("{project_id}_bulk_metadata.tsv"))
+      if (file.exists(project_bulk_tsv)) {
+        fs::file_copy(project_bulk_tsv, bulk_metadata_scratch_dir, overwrite = TRUE)
+      }
+      
+      if (project_id %in% citeseq_projects) {
+        fs::file_copy(
+          file.path(project_scratch_dir, glue::glue("single_cell_metadata.tsv")), 
+          file.path(citeseq_metadata_scratch_dir, glue::glue("{project_id}_single_cell_metadata.tsv")), 
+          overwrite = TRUE
+        )
+      }
 
       # If this project is used in the bulk analysis, copy to bulk_project_dir
       # We do this after copying samples above since we don't want to remove their (un)filtered files
@@ -276,7 +299,7 @@ input_zips |>
         system(glue::glue("rm {project_scratch_dir}/*/*filtered.rds"))
         system(glue::glue("rm {project_scratch_dir}/*/*html"))
 
-        fs::dir_copy(project_scratch_dir, opts$bulk_data_dir)
+        fs::dir_copy(project_scratch_dir, opts$bulk_data_dir, overwrite = TRUE)
       }
 
       ####### Step 2: Prepare consensus cell type files #######
@@ -330,17 +353,19 @@ sample_metadata_file <- file.path(opts$s3_files_dir, "scpca-sample-metadata.tsv"
 library_metadata_file <- file.path(opts$s3_files_dir, "scpca-library-metadata.tsv")
 
 # Create and export sample metadata table
- portal_metadata |>
+portal_metadata |>
   dplyr::select(scpca_project_id, scpca_sample_id, diagnosis, disease_timing, is_cell_line) |>
   # remove duplicate rows, which occur when there are multiple libraries per sample
   dplyr::distinct() |>
   readr::write_tsv(sample_metadata_file)
 
 # Create and export library metadata table
-library_metadata <- portal_metadata |>
-  dplyr::select(scpca_project_id, scpca_sample_id, scpca_library_id, seq_unit, technology) |>
-  readr::write_tsv(library_metadata_file)
-
+prepare_library_metadata(
+  portal_metadata, 
+  bulk_metadata_scratch_dir,
+  citeseq_metadata_scratch_dir,
+  library_metadata_file
+)
 
 # Sync reference files from S3 ------------------------------------
 

--- a/reproduce-figures/utils.R
+++ b/reproduce-figures/utils.R
@@ -78,6 +78,40 @@ prepare_gene_expression_tsv <- function(sce, marker_genes, output_tsv) {
 
 
 
+
+#' Prepare and export sample metadata file
+#'
+#' @param portal_metadata Data frame of portal-wide metadata
+#' @param output_tsv Path to output TSV file
+#'
+prepare_sample_metadata <- function(
+    portal_metadata, 
+    output_tsv) {
+  
+  sample_metadata <- portal_metadata |>
+    dplyr::select(scpca_project_id, scpca_sample_id, diagnosis, disease_timing, is_cell_line) |>
+    # remove duplicate rows, which occur when there are multiple libraries per sample
+    dplyr::distinct()
+  
+  # Prepare data frame with samples whose full metadata is not yet available on the portal
+  bulk_only_sample_metadata <-  tibble::tribble(
+    ~scpca_project_id, ~scpca_sample_id, ~diagnosis,        ~disease_timing,     ~is_cell_line, 
+    ###########################################################################################
+    "SCPCP000006",     "SCPCS000210",    "Wilms tumor",     "Initial diagnosis", FALSE,
+    "SCPCP000006",     "SCPCS000211",    "Wilms tumor",     "Initial diagnosis", FALSE,
+    "SCPCP000009",     "SCPCS000129",    "Medulloblastoma", "Initial diagnosis", FALSE,
+    "SCPCP000017",     "SCPCS000606",    "Osteosarcoma",    "Recurrence",        FALSE
+  )
+  
+  sample_metadata |>
+    dplyr::bind_rows(bulk_only_sample_metadata) |>
+    readr::write_tsv(output_tsv)
+}
+  
+  
+  
+
+
 #' Prepare and export library metadata file
 #'
 #' @param portal_metadata Data frame of portal-wide metadata
@@ -100,19 +134,19 @@ prepare_library_metadata <- function(
     "technology"
   )
   
-  portal_metadata <- portal_metadata |>
+  library_metadata <- portal_metadata |>
     # Group multiplexed sample ids back together; keep has_cellhash for later manipulation
     dplyr::group_by(scpca_project_id, scpca_library_id, seq_unit, technology, has_cellhash) |>
     dplyr::summarize(scpca_sample_id = paste(scpca_sample_id, collapse = ";")) |>
     dplyr::ungroup()
   
   # duplicate multiplexed rows so we have a row for cellhash technology
-  cellhash_rows <- portal_metadata |>
+  cellhash_rows <- library_metadata |>
     dplyr::filter(has_cellhash) |>
     # in our code, we detect this technology with "cellhash" only, so the version isn't needed
     dplyr::mutate(technology = "cellhash")
     
-  portal_metadata <- portal_metadata |>
+  library_metadata <- library_metadata |>
     dplyr::bind_rows(cellhash_rows) |>
     dplyr::select(-has_cellhash)
   
@@ -155,7 +189,7 @@ prepare_library_metadata <- function(
     purrr::list_rbind()
   
   # Combine data frames and export
-  portal_metadata |>
+  library_metadata |>
     dplyr::bind_rows(bulk_metadata) |>
     dplyr::bind_rows(cite_metadata) |>
     readr::write_tsv(output_tsv)

--- a/reproduce-figures/utils.R
+++ b/reproduce-figures/utils.R
@@ -91,19 +91,30 @@ prepare_library_metadata <- function(
     project_metadata_dir, 
     output_tsv) {
   
+  # final columns to include in the exported library metadata tsv
+  final_columns <- c(
+    "scpca_project_id",
+    "scpca_sample_id",
+    "scpca_library_id",
+    "seq_unit",
+    "technology"
+  )
+  
   portal_metadata <- portal_metadata |>
-    # Select columns of interest
-    dplyr::select(
-      scpca_project_id,
-      scpca_sample_id,
-      scpca_library_id,
-      seq_unit, 
-      technology
-    ) |>
-    # Group multiplexed sample ids back together
-    dplyr::group_by(scpca_project_id, scpca_library_id, seq_unit, technology) |>
-    dplyr::summarize(scpca_sample_id = paste(scpca_sample_id, collapse = ";"))
+    # Group multiplexed sample ids back together; keep has_cellhash for later manipulation
+    dplyr::group_by(scpca_project_id, scpca_library_id, seq_unit, technology, has_cellhash) |>
+    dplyr::summarize(scpca_sample_id = paste(scpca_sample_id, collapse = ";")) |>
+    dplyr::ungroup()
+  
+  # duplicate multiplexed rows so we have a row for cellhash technology
+  cellhash_rows <- portal_metadata |>
+    dplyr::filter(has_cellhash) |>
+    # in our code, we detect this technology with "cellhash" only, so the version isn't needed
+    dplyr::mutate(technology = "cellhash")
     
+  portal_metadata <- portal_metadata |>
+    dplyr::bind_rows(cellhash_rows) |>
+    dplyr::select(-has_cellhash)
   
   # Define bulk and project metadata files
   bulk_files <- list.files(
@@ -111,63 +122,42 @@ prepare_library_metadata <- function(
     pattern = "*_bulk_metadata\\.tsv", 
     full.names = TRUE
   )
-  project_files <- list.files(
+  citeseq_files <- list.files(
     path = project_metadata_dir, 
     pattern = "*_single_cell_metadata\\.tsv", 
     full.names = TRUE
-  ) |>
-    # we need project id identifiers for this one
-    purrr::set_names(\(x) {stringr::str_split_i(basename(x), "_", 1)})
+  ) 
   
   # Parse bulk metadata
   bulk_metadata <- bulk_files |>
     purrr::map(readr::read_tsv) |>
     purrr::list_rbind() |>
-    dplyr::select(
+    dplyr::rename(
       scpca_project_id = project_id, 
       scpca_sample_id = sample_id, 
-      scpca_library_id = library_id, 
-      seq_unit, 
-      technology
-    ) 
+      scpca_library_id = library_id
+    ) |>
+    dplyr::select(all_of(final_columns))
   
-  # Parse project metadata to get rows for CITE-seq & cellhash libraries
-  multimodal_metadata <- project_files |>
-    purrr::imap(
-      \(file, project_id) {
-        metadata_df <- readr::read_tsv(file) 
-        
-        # Get information for cellhash and then CITE-seq projects
-        if (project_id == "SCPCP000009") {
-          metadata_df <- metadata_df |>
-            dplyr::group_by(scpca_project_id, scpca_library_id, seq_unit, technology) |>
-            dplyr::summarize(scpca_sample_id = paste(scpca_sample_id, collapse = ";")) |>
-            dplyr::mutate(technology = "cellhash")
-        } else {
-          metadata_df <- metadata_df |>
-            dplyr::filter(!is.na(adt_filtering_method)) |>
-            dplyr::mutate(technology = "CITE-seq")
-        } 
-        
-        metadata_df <- metadata_df |>
-          dplyr::select(
-            scpca_project_id,
-            scpca_sample_id,
-            scpca_library_id,
-            seq_unit,
-            technology
-          )
+  # Parse project metadata to get rows for CITE-seq
+  cite_metadata <- citeseq_files |>
+    purrr::map(
+      \(file) {
+        metadata_df <- readr::read_tsv(file) |>
+          dplyr::filter(!is.na(adt_filtering_method)) |> 
+          # in our code, we detect this technology with "CITE" only, so the version isn't needed
+          dplyr::mutate(technology = "CITEseq") |>
+          dplyr::select(all_of(final_columns))
         
         return(metadata_df)
       }
     ) |>
-    purrr::list_rbind() |>
-    dplyr::ungroup()
+    purrr::list_rbind()
   
   # Combine data frames and export
   portal_metadata |>
     dplyr::bind_rows(bulk_metadata) |>
-    dplyr::bind_rows(multimodal_metadata) |>
-    dplyr::arrange(scpca_project_id) |>
+    dplyr::bind_rows(cite_metadata) |>
     readr::write_tsv(output_tsv)
 }
+

--- a/reproduce-figures/utils.R
+++ b/reproduce-figures/utils.R
@@ -1,8 +1,5 @@
-# This file contains functions used in prepare-scpca-portal-data.R to process consensus cell types.
-
-
-
-
+# This file contains functions used in prepare-scpca-portal-data.R to process consensus cell types
+#  and to create metadata files.
 
 #' Prepare and export TSV of consensus cell types
 #'

--- a/reproduce-figures/utils.R
+++ b/reproduce-figures/utils.R
@@ -75,3 +75,99 @@ prepare_gene_expression_tsv <- function(sce, marker_genes, output_tsv) {
   # export the marker gene expression tsv
   readr::write_tsv(gene_exp_df, output_tsv)
 }
+
+
+
+#' Prepare and export library metadata file
+#'
+#' @param portal_metadata Data frame of portal-wide metadata
+#' @param bulk_metadata_dir Directory with bulk metadata TSV files
+#' @param project_metadata_dir Directory with project-specific metadata TSV files
+#' @param output_tsv Path to output TSV file
+#'
+prepare_library_metadata <- function(
+    portal_metadata, 
+    bulk_metadata_dir, 
+    project_metadata_dir, 
+    output_tsv) {
+  
+  portal_metadata <- portal_metadata |>
+    # Select columns of interest
+    dplyr::select(
+      scpca_project_id,
+      scpca_sample_id,
+      scpca_library_id,
+      seq_unit, 
+      technology
+    ) |>
+    # Group multiplexed sample ids back together
+    dplyr::group_by(scpca_project_id, scpca_library_id, seq_unit, technology) |>
+    dplyr::summarize(scpca_sample_id = paste(scpca_sample_id, collapse = ";"))
+    
+  
+  # Define bulk and project metadata files
+  bulk_files <- list.files(
+    path = bulk_metadata_dir, 
+    pattern = "*_bulk_metadata\\.tsv", 
+    full.names = TRUE
+  )
+  project_files <- list.files(
+    path = project_metadata_dir, 
+    pattern = "*_single_cell_metadata\\.tsv", 
+    full.names = TRUE
+  ) |>
+    # we need project id identifiers for this one
+    purrr::set_names(\(x) {stringr::str_split_i(basename(x), "_", 1)})
+  
+  # Parse bulk metadata
+  bulk_metadata <- bulk_files |>
+    purrr::map(readr::read_tsv) |>
+    purrr::list_rbind() |>
+    dplyr::select(
+      scpca_project_id = project_id, 
+      scpca_sample_id = sample_id, 
+      scpca_library_id = library_id, 
+      seq_unit, 
+      technology
+    ) 
+  
+  # Parse project metadata to get rows for CITE-seq & cellhash libraries
+  multimodal_metadata <- project_files |>
+    purrr::imap(
+      \(file, project_id) {
+        metadata_df <- readr::read_tsv(file) 
+        
+        # Get information for cellhash and then CITE-seq projects
+        if (project_id == "SCPCP000009") {
+          metadata_df <- metadata_df |>
+            dplyr::group_by(scpca_project_id, scpca_library_id, seq_unit, technology) |>
+            dplyr::summarize(scpca_sample_id = paste(scpca_sample_id, collapse = ";")) |>
+            dplyr::mutate(technology = "cellhash")
+        } else {
+          metadata_df <- metadata_df |>
+            dplyr::filter(!is.na(adt_filtering_method)) |>
+            dplyr::mutate(technology = "CITE-seq")
+        } 
+        
+        metadata_df <- metadata_df |>
+          dplyr::select(
+            scpca_project_id,
+            scpca_sample_id,
+            scpca_library_id,
+            seq_unit,
+            technology
+          )
+        
+        return(metadata_df)
+      }
+    ) |>
+    purrr::list_rbind() |>
+    dplyr::ungroup()
+  
+  # Combine data frames and export
+  portal_metadata |>
+    dplyr::bind_rows(bulk_metadata) |>
+    dplyr::bind_rows(multimodal_metadata) |>
+    dplyr::arrange(scpca_project_id) |>
+    readr::write_tsv(output_tsv)
+}


### PR DESCRIPTION
Closes #259 (if pursued!)

This PR updates our approach for preparing metadata files for reproducibility, according to the scheme I laid out in my opening comment of #259.

To get the full library information we need, I also save and parse bulk metadata TSVs and metadata TSVs for projects with CITE-seq, and handle cellhash samples a bit more carefully to ensure we get their technology information. To get the full sample information we need, I manually add in a table with the information we need.

The result seems to sufficiently match our metadata files! I used these new files, for example, to re-create Table S1 and Table S2. No diff for Table S2 🎉, but for Table S1 these versions of the metadata led to one diff from the table made with our internal metadata - the diagnosis for SCPCP000009 are in a different order, but are all the same. This is presumably just a row order thing and I'm not worried about it (unless we want to sort somehow in general) since the table has the same content.

At some point while I was here too, I made a few other changes (which can be cherry-picked out if we prefer):
 a bit of rearranging of directory definitions (eg the merged sce directory) to place them all higher in the script to create them all at once. I also fixed an exciting bug where I had called the library metadata file `"library-sample-metadata.tsv"`, which is...not correct.