### PR TITLE
Reproducibility updates for consensus cell types

### DIFF
--- a/reproduce-figures/README.md
+++ b/reproduce-figures/README.md
@@ -28,17 +28,18 @@ Please refer to the [Introduction to `renv` vignette](https://rstudio.github.io/
 You will need to download the following files from the ScPCA Portal <https://scpca.alexslemonade.org/>:
 
 1. All ScPCA projects listed in the [project whitelist file](../sample-info/project-whitelist.txt)
-  * Use the project identifiers listed in the project whitelist file to navigate to each project page.
-For example, to navigate to `SCPCP000001`, use the URL: <https://scpca.alexslemonade.org/projects/SCPCP000001>.
+  * Use the project identifiers listed in the project whitelist file to navigate to each project page
+For example, to navigate to `SCPCP000001`, use the URL: <https://scpca.alexslemonade.org/projects/SCPCP000001>
 * Download each project using the `Download Project` button with the following options selected:
     * Ensure the selected modality is `Single-cell`
     * Ensure the selected Data Format is `SingleCellExperiment (r)`
     * Do _not_ click to merge all objects into the same sample
     * If the project contains multiplexed samples, you can exclude those samples (but it will not affect the code if they are included)
-  * These projects will download as zip files; you should leave them in this compressed format, and _do not rename them_.
+  * These projects will download as zip files; you should leave them in this compressed format, and _do not rename them_
 
-2. The portal-wide metadata TSV file
-  * You can download this single TSV file using the "Get All Sample Metadata" button on the top-right of the portal homepage.
+2. The portal-wide metadata file
+  * You can download this file using the "Get All Sample Metadata" button on the top-right of the portal homepage
+  * This will download as a zip file; you should leave it in this compressed format
 
 
 ### Step 3: Organize your downloaded files
@@ -74,6 +75,6 @@ For more options, use the `--help` flag.
 
 Once `prepare-scpca-portal-data.R` script has successfully completed running, you will be able to run the following repository scripts to reproduce figures and results:
 
-* [`generate-figures-tables.sh`](../generate-figures-tables.sh): This script creates figure panels and tables used in the manuscript by running all R scripts in `scripts/`.
-  * As such you can now run individual scripts in `scripts/`; however, the scripts in `scripts/figure_setup/` are intended for internal Data Lab use only.
-* [`analysis/pseudobulk-bulk-prediction/run-prediction.sh`](../analysis/pseudobulk-bulk-prediction/run-prediction.sh): This script runs the bulk/pseudobulk expression analysis, which may take several hours to complete.
+* [`generate-figures-tables.sh`](../generate-figures-tables.sh): This script creates figure panels and tables used in the manuscript by running all R scripts in `../scripts/`
+  * As such you can now run individual scripts in `../scripts/`; however, the scripts in `../scripts/figure_setup/` are intended for internal Data Lab use only
+* [`analysis/pseudobulk-bulk-prediction/run-prediction.sh`](../analysis/pseudobulk-bulk-prediction/run-prediction.sh): This script runs the bulk/pseudobulk expression analysis, which may take several hours to complete

--- a/reproduce-figures/prepare-scpca-portal-data.R
+++ b/reproduce-figures/prepare-scpca-portal-data.R
@@ -19,7 +19,7 @@
 #
 #   Rscript prepare-scpca-portal-data.R \
 #     --portal_projects_dir <path to directory with all project zip files> \
-#     --portal_metadata_path <path to portal-wide metadata TSV>
+#     --portal_metadata_path <path to portal-wide metadata zip file>
 
 renv::load()
 suppressPackageStartupMessages({
@@ -37,7 +37,7 @@ option_list <- list(
   make_option(
     "--portal_metadata_path",
     type = "character",
-    help = "Path to the the portal-wide metadata TSV"
+    help = "Path to the the portal-wide metadata file as a compressed ZIP file"
   ),
   make_option(
     "--s3_files_dir",
@@ -88,9 +88,11 @@ stopifnot(
 )
 stopifnot(
   "Portal projects directory not found" = dir.exists(opts$portal_projects_dir),
-  "Portal-wide metadata TSV not found" = file.exists(opts$portal_metadata_path),
+  "Portal-wide metadata file not found" = file.exists(opts$portal_metadata_path),
   "Project whitelist could not be found" = file.exists(opts$project_whitelist)
 )
+
+
 
 # Check output directories
 
@@ -118,20 +120,35 @@ s3_files_reference_dir <- file.path(opts$s3_files_dir, "reference_files")
 merged_sce_dir <- file.path(opts$s3_files_dir, "SCPCP000003")
 
 # these directories are for temporary file stored in scratch
+portal_metadata_scratch_dir <- file.path(opts$scratch_dir, "portal-metadata")
 bulk_metadata_scratch_dir <- file.path(opts$scratch_dir, "bulk-metadata")
 citeseq_metadata_scratch_dir <- file.path(opts$scratch_dir, "citeseq-project-metadata")
 
 
 fs::dir_create(c(
-  opts$scratch_dir,
   output_dirs,
   consensus_files_dir,
   celltype_results_dir,
   s3_files_reference_dir,
   merged_sce_dir,
   bulk_metadata_scratch_dir,
-  citeseq_metadata_scratch_dir
+  citeseq_metadata_scratch_dir, 
+  portal_metadata_scratch_dir
 ))
+
+
+# Read input metadata file and define output metadata files
+# Note that we need directory definitions before reading this in
+# first, confirm it's a zip file
+stopifnot(
+  "The portal metadata file is expected to be a compressed ZIP file." = stringr::str_ends(tolower(opts$portal_metadata_path), "zip")
+)
+unzip(opts$portal_metadata_path, exdir = portal_metadata_scratch_dir)
+portal_metadata <- readr::read_tsv(
+  file.path(portal_metadata_scratch_dir, "metadata.tsv") # The downloaded metadata from the portal is literally named metadata.tsv
+)
+sample_metadata_file <- file.path(opts$s3_files_dir, "scpca-sample-metadata.tsv")
+library_metadata_file <- file.path(opts$s3_files_dir, "scpca-library-metadata.tsv")
 
 
 # These are all output directories at the top-level of s3_files
@@ -329,11 +346,6 @@ input_zips |>
 
 
 # Prepare sample and library metadata files ---------------------------
-
-# Read input metadata file
-portal_metadata <- readr::read_tsv(opts$portal_metadata_path)
-sample_metadata_file <- file.path(opts$s3_files_dir, "scpca-sample-metadata.tsv")
-library_metadata_file <- file.path(opts$s3_files_dir, "scpca-library-metadata.tsv")
 
 # Create and export sample metadata table
 prepare_sample_metadata(

--- a/reproduce-figures/utils.R
+++ b/reproduce-figures/utils.R
@@ -11,9 +11,7 @@ prepare_consensus_tsv <- function(sce, output_tsv){
   # Define consensus cell types since they won't be present in SCEs which were not
   #  annotated with both SingleR and CellAssign
   if ("consensus_celltype_annotation" %in% names(colData(sce))) {
-    # TODO: This column needs to be updated
-    # See https://github.com/AlexsLemonade/scpca-paper-figures/issues/253
-    consensus_celltypes <- sce$singler_celltype_annotation
+    consensus_celltypes <- sce$consensus_celltype_annotation
   } else {
     consensus_celltypes <- NA
   }

--- a/scripts/utils/consensus-celltype-plotting-functions.R
+++ b/scripts/utils/consensus-celltype-plotting-functions.R
@@ -97,7 +97,7 @@ marker_gene_dotplot <- function(
       percent_exp = (detected_count / total_cells) * 100,
       # account for NA/unknowns and set axes order
       broad_celltype_group = tidyr::replace_na(broad_celltype_group, "unknown") |>
-        factor(levels = c(names(celltype_colors), "unknown"))
+        factor(levels = unique(c(names(celltype_colors), "unknown")))
     )
 
   # get list of celltypes to keep and assign colors


### PR DESCRIPTION
Closes #253 

This PR makes a couple changes to fully reproducibility of manuscript figures and tables:

- Per the original goal of #253, I updated the cell type column to parse consensus cell types and removed the singler placeholder
- Since the metadata file download is actually a zip file which contains a file `metadata.tsv`, I updated code and docs to account for this. Rather than reading a TSV, I check that it's a ZIP file, unzip it into a dedicated directory in `scratch`, and read in `metadata.tsv` from there.
- When running the dotplot code, I got a factor bug because the `unknown` level was repeated. I am pretty sure we could just safely remove the "unknown"` from this levels vector but I was nervous so instead just put it in a `unique()`! Either way the code is all running now :)