### PR TITLE
Add a unique

### DIFF
--- a/reproduce-figures/utils.R
+++ b/reproduce-figures/utils.R
@@ -106,6 +106,8 @@ prepare_sample_metadata <- function(
 
   sample_metadata |>
     dplyr::bind_rows(bulk_only_sample_metadata) |>
+    # ensure no duplicate rows
+    unique() |>
     readr::write_tsv(output_tsv)
 }
 


### PR DESCRIPTION
Closes #283 

As described in the linked issue, we are updating portal metadata such that we may end up with duplicated rows when recreating metadata from the portal since we hardcode a couple samples that are _currently_ missing from the portal-wide tsv. Adding this `unique()` should protect us without having to get into the weeds.

(Worth noting that if we also incorporate bulk metadata into the portal-wide tsv, we could simplify other parsing aspects here, but that really doesn't seem worth the effort since the changes shouldn't _break_ anything!)