### PR TITLE
Expand validation group palette

### DIFF
--- a/palettes/validation-group-palette.tsv
+++ b/palettes/validation-group-palette.tsv
@@ -6,7 +6,7 @@ innate lymphoid cell	#325A9B
 dendritic cell	#16FF32
 macrophage	#1C8356
 monocyte	#1CBE4F
-myeloid	#90AD1C
+myeloid cell	#90AD1C
 natural killer cell	#FBE426
 hematopoietic precursor cell	#FEAF16
 stem cell	#F7E1A0
@@ -15,12 +15,18 @@ chondrocyte	#B00068
 endothelial cell	#FC1CBF
 epithelial cell	#C075A6
 fibroblast	#B10DA1
-melanocyte	#FE00FA
+myofibroblast cell	#FE00FA
 muscle cell	#F6222E
 pericyte	#F8A19F
 stromal cell	#C4451C
 neuron	#1CFFCE
 astrocyte	#2ED9FF
 glial cell	#565656
-mesangial cell	#E2E2E2
+mesangial cell	#CCD2D8
 unknown	#E5E5E5
+pigment cell	#5A1A00
+kidney cell	#8A8F6A
+endocrine cell	#FF7A00
+embryonic cell (metazoa)	#CEC3B2
+ciliated cell	#00B3B3
+cardiocyte	#7A0019


### PR DESCRIPTION
Closes #292 

It's time for more colors! This PR adds 6 new colors to the validation group palette, along with these other small changes:
- I toggled in myofibroblast for melanocyte which we no longer need
- I updated the mesangial cell color to shade it a smidge cooler, since to my eye it's really colliding with "unknown"
- I renamed myeloid -> myeloid cell, since this is now what we call it.

Here's the wholesale new colors:

mesangial cell	`#CCD2D8` (used to be `#E2E2E2` which I couldn't distinguish from our unknown `#E5E5E5`)
pigment cell	`#5A1A00`
kidney cell	`#8A8F6A`
endocrine cell	`#FF7A00`
embryonic cell (metazoa)	`#CEC3B2`
ciliated cell	`#00B3B3`
cardiocyte	`#7A0019`


I also ran locally the barplots which use these colors to see how they would look in action, and I can see the differences especially given which cells are in each plot. I'm copy in the legends that are affected here; all but the leukemia barplot. Note that these plots will need to be resized when we actually remake them since they're now too big for the pdf dimensions, but the purpose of these screenshots is just to see how the colors go together.

## brain/cns 

<img width="274" height="266" alt="brain legend" src="https://github.com/user-attachments/assets/b2fa6711-d2cc-4413-98c3-bad2f1cb8920" />

## sarcoma 

<img width="500" height="150" alt="sarcoma legend" src="https://github.com/user-attachments/assets/d13a359f-d478-43c2-8984-c0797427f7c7" />

## other solid tumors

<img width="1004" height="256" alt="other solid legend" src="https://github.com/user-attachments/assets/0955249a-9c8f-4465-8d3e-f03bb8d89694" />


---

Requesting a few eyeballs here for review, since this is a tricky one!

